### PR TITLE
added little padding to line chart

### DIFF
--- a/public/angular-app/d3/d3-multi-series-brushed-chart.js
+++ b/public/angular-app/d3/d3-multi-series-brushed-chart.js
@@ -73,6 +73,8 @@ angular.module('MissionControlApp').directive('d3MultiSeriesLineBrushed', ['d3',
                     });
                 });
 
+                maxValue = Math.ceil((maxValue+1) / 10) * 10; // round up to nearest 10
+
                 y.domain([0, maxValue]);
                 x2.domain(x.domain());
                 y2.domain(y.domain());

--- a/public/angular-app/health-report/link-stats/link-stats.html
+++ b/public/angular-app/health-report/link-stats/link-stats.html
@@ -37,7 +37,10 @@
                 </div>
                 <div id="collapseP3" class="panel-collapse collapse in">
                     <div class="panel-body no-padding" ng-if="vm.LinkData.linkStats.linkStats.length >= 2">
-                        <d3-multi-series-line-brushed data="vm.LinkData.linkStats.linkStats" keys="vm.StylesKeys" reference-line="vm.d3GoalLine"></d3-multi-series-line-brushed>
+                        <d3-multi-series-line-brushed data="vm.LinkData.linkStats.linkStats"
+                                                      keys="vm.StylesKeys"
+                                                      reference-line="vm.d3GoalLine">
+                        </d3-multi-series-line-brushed>
                     </div>
                 </div>
             </div>

--- a/public/angular-app/health-report/view-stats/views-stats.html
+++ b/public/angular-app/health-report/view-stats/views-stats.html
@@ -37,7 +37,10 @@
                 </div>
                 <div id="collapseP1" class="panel-collapse collapse in" ng-if="vm.ViewData.viewStats.viewStats.length >= 2">
                     <div class="panel-body no-padding">
-                        <d3-multi-series-line-brushed data="vm.ViewData.viewStats.viewStats" keys="vm.ViewKeys" reference-line="vm.d3GoalLine"></d3-multi-series-line-brushed>
+                        <d3-multi-series-line-brushed data="vm.ViewData.viewStats.viewStats"
+                                                      keys="vm.ViewKeys"
+                                                      reference-line="vm.d3GoalLine">
+                        </d3-multi-series-line-brushed>
                     </div>
                 </div>
             </div>
@@ -53,7 +56,10 @@
                 </div>
                 <div id="collapseP2" class="panel-collapse collapse in">
                     <div class="panel-body no-padding" ng-if="vm.ViewData.viewStats.viewStats.length >= 2">
-                        <d3-multi-series-line-brushed data="vm.ViewData.viewStats.viewStats" keys="vm.ScheduleKeys" reference-line="vm.d3GoalLine"></d3-multi-series-line-brushed>
+                        <d3-multi-series-line-brushed data="vm.ViewData.viewStats.viewStats"
+                                                      keys="vm.ScheduleKeys"
+                                                      reference-line="vm.d3GoalLine">
+                        </d3-multi-series-line-brushed>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This should solve this issue: https://github.com/HOKGroup/MissionControl/issues/198

The problem was that SVG line had a thickness, and since our domain was calculated exactly to max value, it was being chopped off a little and looking weird. 

This fixed it: `maxValue = Math.ceil((maxValue+1) / 10) * 10; // round up to nearest 10`