### PR TITLE
pushed warnings table processing to server

### DIFF
--- a/app/controller/filepaths.js
+++ b/app/controller/filepaths.js
@@ -296,8 +296,8 @@ FilePathsService = {
                 status: 201,
                 message: {
                     draw: req.body['draw'],
-                    recordsTotal: response.length - 1,
-                    recordsFiltered: filtered.length > 0 ? filtered.length - 1 : response.length - 1,
+                    recordsTotal: response.length,
+                    recordsFiltered: filtered.length > 0 ? filtered.length : response.length,
                     data: data
                 }
             };
@@ -310,7 +310,6 @@ FilePathsService = {
             }
             res.status(result.status).json(result.message);
         });
-
     }
 };
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -138,6 +138,7 @@ var users = require('./models/users');
      app.get('/api/v2/warnings/centralpath/:uri*/open', warnings.getOpen);
      app.post('/api/v2/warnings/daterange', warnings.getWarningStats);
      app.put('/api/v2/warnings/updatefilepath', warnings.updateFilePath);
+     app.post('/api/v2/warnings/datatable', warnings.datatable);
 
      var filepaths = require('./controller/filepaths');
      app.get('/api/v2/filepaths', filepaths.getAll);

--- a/public/angular-app/data-factory/health-report-data-factory.js
+++ b/public/angular-app/data-factory/health-report-data-factory.js
@@ -97,16 +97,16 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                     var familyScoreData = {
                         passingChecks: passingChecks,
                         count: familyStats.totalFamilies,
-                        label: "Families",
+                        label: 'Families',
                         newMax: 8};
 
                     // (Konrad) This score needs to be remapped to 0-6 range
                     var familyScore = Math.round((passingChecks * 6)/8);
 
-                    var desc = "Families are integral part of Revit functionality. It is however, important to remember," +
-                        "that oversized (>1MB) families can be a sign of trouble (poorly modeled, imported DWGs etc.). That's " +
-                        "why it's imperative to follow HOK's best practices in modeling and naming Revit Families. InPlace families " +
-                        "should be limited in use as they do not allow full functionality of the regular Families.";
+                    var desc = 'Families are integral part of Revit functionality. It is however, important to remember,' +
+                        'that oversized (>1MB) families can be a sign of trouble (poorly modeled, imported DWGs etc.). That\'s ' +
+                        'why it\'s imperative to follow HOK\'s best practices in modeling and naming Revit Families. InPlace families ' +
+                        'should be limited in use as they do not allow full functionality of the regular Families.';
 
                     var bullets = [
                         {
@@ -157,10 +157,10 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                         scoreData: familyScoreData,
                         familyScore: familyScore,
                         description: desc,
-                        name: "Families",
+                        name: 'Families',
                         familyStats: familyStats,
                         bullets: bullets,
-                        show: {name: "families", value: false},
+                        show: {name: 'families', value: false},
                         color: color,
                         userNames: userNames
                     });
@@ -187,7 +187,7 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                         response.data.linkStats.length === 0){
                         callback({
                             linkStats: response.data
-                        })
+                        });
                     } else {
                         var data = response.data;
                         var latest = data.linkStats[data.linkStats.length - 1];
@@ -225,15 +225,15 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                         var linkScoreData = {
                             passingChecks: passingChecks,
                             count: latest.totalImportedDwg,
-                            label: "Import Instances",
+                            label: 'Import Instances',
                             newMax: 6};
 
-                        var desc = "Excessive linking of RVT/DWG/NWC files " +
-                            "can impact file performance even if the file is otherwise well maintained. Each linked Revit model should " +
-                            "be placed on its own Workset to allow it to be closed, and conserve resources. " +
-                            "This model has " + (latest.totalLinkedModels - latest.totalLinkedDwg) + " Linked Revit Models, " +
-                            "and " + latest.totalLinkedDwg + " Linked CAD Files. These links were placed " + latest.totalImportedDwg + " times." +
-                            "\n*Not all links have to be placed.";
+                        var desc = 'Excessive linking of RVT/DWG/NWC files ' +
+                            'can impact file performance even if the file is otherwise well maintained. Each linked Revit model should ' +
+                            'be placed on its own Workset to allow it to be closed, and conserve resources. ' +
+                            'This model has ' + (latest.totalLinkedModels - latest.totalLinkedDwg) + ' Linked Revit Models, ' +
+                            'and ' + latest.totalLinkedDwg + ' Linked CAD Files. These links were placed ' + latest.totalImportedDwg + ' times.' +
+                            '\n*Not all links have to be placed.';
 
                         var bullets = [
                             {
@@ -274,17 +274,17 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                             importedFiles: latest.importedDwgFiles,
                             linkScore: linkScoreData.passingChecks,
                             description: desc,
-                            name: "Links",
+                            name: 'Links',
                             linkStats: data,
                             bullets: bullets,
-                            show: {name: "links", value: false},
+                            show: {name: 'links', value: false},
                             color: color
                         });
                     }
                 })
                 .catch(function (error) {
                     console.log(error);
-                })
+                });
         },
 
         /**
@@ -304,7 +304,7 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                         response.data.styleStats.length === 0){
                         callback({
                             styleStats: response.data
-                        })
+                        });
                     } else {
                         var data = response.data;
                         var latest = data.styleStats[0]; //we filter this data on server side so only 1 doc is returned
@@ -354,7 +354,7 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                         var styleScoreData = {
                             passingChecks: passingChecks,
                             count: unusedTypes,
-                            label: "Unused Styles",
+                            label: 'Unused Styles',
                             newMax: 8};
 
                         // (Konrad) This score needs to be remapped to 0-6 range
@@ -419,17 +419,17 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                             scoreData: styleScoreData,
                             styleScore: styleScore,
                             description: desc,
-                            name: "Styles",
+                            name: 'Styles',
                             styleStats: data,
                             bullets: bullets,
-                            show: {name: "styles", value: false},
+                            show: {name: 'styles', value: false},
                             color: color
                         });
                     }
                 })
                 .catch(function (error) {
                     console.log(error);
-                })
+                });
         },
 
         /**
@@ -452,7 +452,7 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                         // property needed to re-call this filter without crashing.
                         callback({
                             viewStats: response.data
-                        })
+                        });
                     } else {
                         var data = response.data;
                         var latest = data.viewStats[data.viewStats.length - 1];
@@ -503,7 +503,7 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                         var viewScoreData = {
                             passingChecks: passingChecks,
                             count: latest.totalViews,
-                            label: "Views",
+                            label: 'Views',
                             newMax: 8};
 
                         // (Konrad) This score needs to be remapped to 0-6 range
@@ -562,17 +562,17 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                             scoreData: viewScoreData,
                             viewScore: viewScore,
                             description: desc,
-                            name: "Views",
+                            name: 'Views',
                             viewStats: data,
                             bullets: bullets,
-                            show: {name: "views", value: false},
+                            show: {name: 'views', value: false},
                             color: color
                         });
                     }
                 })
                 .catch(function (error) {
                     console.log(error);
-                })
+                });
         },
 
         /**
@@ -619,13 +619,13 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                         };
 
                         var modelSize = UtilityService.formatNumber(data.modelSizes[data.modelSizes.length-1].value);
-                        var avgOpenTime = UtilityService.formatDuration(SumProperty(data.openTimes, "value") / data.openTimes.length);
-                        var avgSynchTime = UtilityService.formatDuration(SumProperty(data.synchTimes, "value") / data.openTimes.length);
+                        var avgOpenTime = UtilityService.formatDuration(SumProperty(data.openTimes, 'value') / data.openTimes.length);
+                        var avgSynchTime = UtilityService.formatDuration(SumProperty(data.synchTimes, 'value') / data.openTimes.length);
 
                         var modelScoreData = {
                             passingChecks: 7,
                             count: modelSize,
-                            label: "Model Size",
+                            label: 'Model Size',
                             newMax: 6
                         };
 
@@ -670,10 +670,10 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                             scoreData: modelScoreData,
                             modelScore: 7,
                             description: desc,
-                            name: "Model",
+                            name: 'Model',
                             modelStats: data,
                             bullets: bullets,
-                            show: {name: "models", value: false},
+                            show: {name: 'models', value: false},
                             color: UtilityService.color().grey
                         });
                     }
@@ -721,7 +721,7 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                                 user: item.user,
                                 onOpened: (item.opened * 100) / (item.closed + item.opened),
                                 onSynched: 0} // this will be filled out later
-                            )
+                            );
                         });
 
                         var synched = CalculateTotals(worksetData.onSynched);
@@ -744,7 +744,7 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                         // (Konrad) Process data to append d3 compatible structure
                         var keys = Object.keys(output[0])
                             .filter(function(x){
-                                return x !== "user";
+                                return x !== 'user';
                             });
 
                         output.forEach(function(x){
@@ -769,30 +769,30 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
 
                         // (Konrad) This section collects all data about Workset Item Counts (horizontal bar chart)
                         // Returns most recently added workset count information (response.data.itemCount.length-1)
-                        var onlyDefaultWorksets = "No";
+                        var onlyDefaultWorksets = 'No';
                         var onlyDefaultWorksetsColor = UtilityService.color().green;
-                        var contentOnSingleWorkset = "No";
+                        var contentOnSingleWorkset = 'No';
                         var contentOnSingleWorksetColor = UtilityService.color().green;
                         var unusedWorksets = 0;
                         var unusedWorksetsColor = UtilityService.color().green;
                         var workset1 = false;
                         var sharedLevels = false;
                         var overallCount = worksetItemCountData.length;
-                        var worksetCountTotal = SumProperty(worksetItemCountData, "count");
+                        var worksetCountTotal = SumProperty(worksetItemCountData, 'count');
 
                         worksetItemCountData.forEach(function (item) {
                             if(item.count <= 0) unusedWorksets += 1;
-                            if(item.name === "Workset1") workset1 = true;
-                            if(item.name === "Shared Levels and Grids") sharedLevels = true;
+                            if(item.name === 'Workset1') workset1 = true;
+                            if(item.name === 'Shared Levels and Grids') sharedLevels = true;
                             if((item.count * 100)/worksetCountTotal >= 50) {
                                 contentOnSingleWorksetColor = UtilityService.color().red;
-                                contentOnSingleWorkset = "Yes";
+                                contentOnSingleWorkset = 'Yes';
                             }
                         });
 
                         if(workset1 && sharedLevels && overallCount === 2){
                             onlyDefaultWorksetsColor = UtilityService.color().red;
-                            onlyDefaultWorksets = "Yes";
+                            onlyDefaultWorksets = 'Yes';
                         }
 
                         var passingChecks = 0;
@@ -801,13 +801,13 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                         } else {
                             unusedWorksetsColor = UtilityService.color().red;
                         }
-                        if(onlyDefaultWorksets === "No") passingChecks += 2;
-                        if(contentOnSingleWorkset === "No") passingChecks += 2;
+                        if(onlyDefaultWorksets === 'No') passingChecks += 2;
+                        if(contentOnSingleWorkset === 'No') passingChecks += 2;
 
                         var worksetScoreData = {
                             passingChecks: passingChecks,
                             count: worksetItemCountData.length,
-                            label: "Worksets",
+                            label: 'Worksets',
                             newMax: 6};
 
                         var desc = 'Only open selected Worksets if possible, to minimize the impact the model will ' +
@@ -855,10 +855,10 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                             worksetOpenedData: output,
                             worksetCountTotal: worksetCountTotal,
                             // worksetScore: passingChecks,
-                            name: "Worksets",
+                            name: 'Worksets',
                             color: color,
                             worksetStats: worksetData,
-                            show: {name: "worksets", value: false}
+                            show: {name: 'worksets', value: false}
                         });
                     }
                 })
@@ -886,9 +886,9 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                                 centralPath: data.centralPath
                             });
                         } else {
-                            callback(process(response.data))
+                            callback(process(response.data));
                         }
-                    })
+                    });
             } else {
                 var uri = UtilityService.getHttpSafeFilePath(data.centralPath);
                 WarningsFactory.getByCentralPath(uri).then(function (response) {
@@ -902,11 +902,11 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                             centralPath: data.centralPath
                         });
                     } else {
-                        callback(process(response.data))
+                        callback(process(response.data));
                     }
                 }).catch(function (error) {
                     console.log(error);
-                })
+                });
             }
 
             /**
@@ -933,7 +933,7 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                 var warningScoreData = {
                     passingChecks: passingChecks,
                     count: openWarnings,
-                    label: "Warnings",
+                    label: 'Warnings',
                     newMax: 2
                 };
 
@@ -964,10 +964,10 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                     scoreData: warningScoreData,
                     modelScore: passingChecks,
                     description: desc,
-                    name: "Warnings",
+                    name: 'Warnings',
                     warningStats: data,
                     bullets: bullets,
-                    show: {name: "warnings", value: false},
+                    show: {name: 'warnings', value: false},
                     color: color
                 };
             }
@@ -1040,7 +1040,7 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                         var groupScoreData = {
                             passingChecks: passingChecks,
                             count: data.groupStats.groups.length,
-                            label: "Groups",
+                            label: 'Groups',
                             newMax: 6
                         };
 
@@ -1086,17 +1086,17 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
                             scoreData: groupScoreData,
                             modelScore: passingChecks,
                             description: desc,
-                            name: "Groups",
+                            name: 'Groups',
                             groupStats: data,
                             bullets: bullets,
-                            show: {name: "groups", value: false},
+                            show: {name: 'groups', value: false},
                             color: color
                         });
                     }
                 })
                 .catch(function (error) {
                     console.log(error);
-                })
+                });
         },
 
         /**
@@ -1146,7 +1146,7 @@ function HealthReportFactory(UtilityService, ConfigFactory, ModelsFactory, Style
         var sum = [];
         data.forEach(function(item){
             var existing = sum.filter(function(i){
-                return i.user === item.user
+                return i.user === item.user;
             })[0];
             if(!existing){
                 sum.push(item);

--- a/public/angular-app/health-report/health-report-controller.js
+++ b/public/angular-app/health-report/health-report-controller.js
@@ -6,7 +6,7 @@ function HealthReportController($routeParams, ProjectFactory, HealthReportFactor
     vm.FamilyCollection = null;
     vm.HealthRecords = [];
     vm.AllData = [{
-        show: {name: "main", value: true}
+        show: {name: 'main', value: true}
     }];
     vm.files = [];
 
@@ -52,7 +52,7 @@ function HealthReportController($routeParams, ProjectFactory, HealthReportFactor
      */
     function dynamicSort(property) {
         var sortOrder = 1;
-        if(property[0] === "-") {
+        if(property[0] === '-') {
             sortOrder = -1;
             property = property.substr(1);
         }
@@ -61,7 +61,7 @@ function HealthReportController($routeParams, ProjectFactory, HealthReportFactor
             var prop2 = UtilityService.fileNameFromPath(b[property]);
             var result = (prop1 < prop2) ? -1 : (prop1 > prop2) ? 1 : 0;
             return result * sortOrder;
-        }
+        };
     }
 
     //endregion
@@ -114,7 +114,7 @@ function HealthReportController($routeParams, ProjectFactory, HealthReportFactor
         vm.noData = true;
 
         if (reset) vm.AllData = [{
-            show: {name: "main", value: true}
+            show: {name: 'main', value: true}
         }];
 
         // (Konrad) By default we will take only last month worth of data.

--- a/public/angular-app/health-report/model-stats/model-stats-controller.js
+++ b/public/angular-app/health-report/model-stats/model-stats-controller.js
@@ -151,16 +151,16 @@ function ModelStatsController($timeout, $routeParams, UtilityService, DTColumnBu
         function createTable() {
             vm.dtInstance = {};
             vm.dtOptions = DTOptionsBuilder.fromFnPromise(function () {
-                return getData()
+                return getData();
             }).withPaginationType('simple_numbers')
                 .withDisplayLength(10)
                 .withOption('order', [0, 'asc'])
                 .withOption('lengthMenu', [[10, 25, 50, 100, -1],[10, 25, 50, 100, 'All']])
                 .withOption('rowCallback', function (row, data, index) {
                     if (evaluateEventTime(data)){
-                        row.className = row.className + ' bg-danger'
+                        row.className = row.className + ' bg-danger';
                     } else {
-                        row.className = row.className + ' table-info'
+                        row.className = row.className + ' table-info';
                     }
                 });
 
@@ -282,7 +282,7 @@ function ModelStatsController($timeout, $routeParams, UtilityService, DTColumnBu
                     else if (+item.value < limit && item.user === user) data.push(item);
                 }
             });
-            return {'data' : data, "excludedData" : excludedData}
+            return {'data' : data, 'excludedData' : excludedData};
         }
 
         /**
@@ -290,7 +290,7 @@ function ModelStatsController($timeout, $routeParams, UtilityService, DTColumnBu
          * (Konrad) The idea here is that on synch event Workset info gets posted first so the time
          * stamp for that will have x value. Then when synch is done, a synch time is posted
          * and its time stamp now is y. When we are matching synch times to workset info we
-         * make sure that y-x is not negative which would mean that synch time occured later than
+         * make sure that y-x is not negative which would mean that synch time occurred later than
          * workset info was posted. That would be info for another synch event. If it's positive
          * then we are looking for the smallest time difference, and that's our synch time/workset data.
          * @param arr
@@ -354,26 +354,26 @@ function ModelStatsController($timeout, $routeParams, UtilityService, DTColumnBu
             vm.ModelSizes = vm.ModelData.modelStats.modelSizes;
 
             // set data for synch charts
-            var filtered = filterData(vm.ModelData.modelStats.synchTimes, synchLimit, "All"); //1h
+            var filtered = filterData(vm.ModelData.modelStats.synchTimes, synchLimit, 'All'); //1h
             vm.ModelSynchTimes = filtered.data;
             vm.ExcludedModelSynchTimes = filtered.excludedData;
 
             // set data for open charts
-            var filtered1 = filterData(vm.ModelData.modelStats.openTimes, openLimit, "All"); //5h
+            var filtered1 = filterData(vm.ModelData.modelStats.openTimes, openLimit, 'All'); //5h
             vm.ModelOpenTimes = filtered1.data;
             vm.ExcludedModelOpenTimes = filtered1.excludedData;
 
             // set data for user filters
-            vm.selectedSynchUser = "All";
-            vm.selectedOpenUser = "All";
+            vm.selectedSynchUser = 'All';
+            vm.selectedOpenUser = 'All';
             vm.OpenUsers = Array.from(new Set(vm.ModelOpenTimes.map(function(item){
                 return item.user;
             })));
-            vm.OpenUsers.unshift("All");
+            vm.OpenUsers.unshift('All');
             vm.SynchUsers = Array.from(new Set(vm.ModelSynchTimes.map(function(item){
                 return item.user;
             })));
-            vm.SynchUsers.unshift("All");
+            vm.SynchUsers.unshift('All');
             vm.selectedTableData = 'Open';
         }
 

--- a/public/angular-app/health-report/warnings/warnings.html
+++ b/public/angular-app/health-report/warnings/warnings.html
@@ -43,7 +43,7 @@
             <!--</div>-->
         <!--</div>-->
     <!--</div>-->
-    <div class="row" ng-if="vm.WarningData.show.value">
+    <div class="row">
         <div class="panel-group">
             <div class="panel panel-default">
                 <div class="panel-heading">
@@ -51,12 +51,13 @@
                 </div>
                 <div class="panel-collapse">
                     <div class="panel-body">
-                        <table id="warningsTable"
+                        <table id="datatable"
                                datatable=""
                                dt-options="vm.dtOptions"
                                dt-columns="vm.dtColumns"
                                dt-instance="vm.dtInstance"
-                               class="table table-hover table-condensed datatable">
+                               class="table table-hover table-condensed datatable"
+                               style="width:100%;">
                         </table>
                     </div>
                 </div>


### PR DESCRIPTION
This resolves the issue of long wait times to display Warnings tables. It is now processed server side instead of in the browser, and also only specific page's data is being shown as opposed to all of the data. 

https://github.com/HOKGroup/MissionControl/issues/194