### PR TITLE
Feature/settings add offices

### DIFF
--- a/app/controller/settings.js
+++ b/app/controller/settings.js
@@ -31,7 +31,7 @@ SettingsService = {
      */
     update: function(req, res) {
         var id = req.params.id;
-        Settings.update({ '_id': id }, req.body, { upsert: true }, function (err, response){
+        Settings.updateOne({ '_id': id }, req.body, { upsert: true }, function (err, response){
             var result = {
                 status: 201,
                 message: response

--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -3,21 +3,34 @@
  */
 var mongoose = require( 'mongoose' );
 
+var officeSchema = new mongoose.Schema(
+    {
+        name: String,
+        code: [String]
+    },
+    {
+        _id: false
+    }
+);
+
 var settingsSchema = new mongoose.Schema(
     {
         // (Konrad) We treat name as a "read only" field.
         name: {
             type: String,
             default: 'Settings',
-            set: function (val) { return 'Settings'; }
+            set: function () { return 'Settings'; }
         },
         httpAddress: {
             type: String,
             default: 'http://missioncontrol.hok.com'
         },
         offices: {
-            type: [String],
-            default: ['New York', 'Chicago']
+            type: [officeSchema],
+            default: [
+                { name: 'All', code: ['All'] },
+                { name: 'New York', code: ['NY'] },
+            ]
         }
     }
 );

--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -14,6 +14,10 @@ var settingsSchema = new mongoose.Schema(
         httpAddress: {
             type: String,
             default: 'http://missioncontrol.hok.com'
+        },
+        offices: {
+            type: [String],
+            default: ['New York', 'Chicago']
         }
     }
 );

--- a/public/angular-app/add-configuration/add-config-controller.js
+++ b/public/angular-app/add-configuration/add-config-controller.js
@@ -5,7 +5,7 @@ angular.module('MissionControlApp').controller('AddConfigController', AddConfigC
 
 function AddConfigController($routeParams, ConfigFactory, ProjectFactory, FilePathsFactory, UtilityService,
                              DTOptionsBuilder, DTColumnBuilder, DTColumnDefBuilder, $uibModal, $window,
-                             $compile, $scope, ngToast){
+                             $compile, $scope, ngToast, SettingsFactory){
 
     //region Init
 
@@ -19,7 +19,7 @@ function AddConfigController($routeParams, ConfigFactory, ProjectFactory, FilePa
     vm.fileWarningMsg = '';
     vm.HasFiles = false;
     vm.files = [];
-    vm.offices = UtilityService.getOffices();
+    vm.settings = null;
     vm.selectedOffice = { name: 'All', code: 'All' };
     vm.fileTypes = [ 'All', 'Local', 'Revit Server', 'BIM 360'];
     vm.selectedType = 'All';
@@ -27,6 +27,7 @@ function AddConfigController($routeParams, ConfigFactory, ProjectFactory, FilePa
     vm.selectedRevitVersion = 'All';
     vm.searchString = '';
 
+    getSettings();
     getSelectedProject(vm.projectId);
     setDefaultConfig();
     createTable();
@@ -284,6 +285,28 @@ function AddConfigController($routeParams, ConfigFactory, ProjectFactory, FilePa
     //endregion
 
     //region Utilities
+
+    /**
+     * Retrieves Mission Control Settings from the DB.
+     */
+    function getSettings() {
+        SettingsFactory.get()
+            .then(function (response) {
+                if(!response || response.status !== 200) throw { message: 'Unable to retrieve the Settings.'};
+
+                vm.settings = response.data;
+            })
+            .catch(function (err) {
+                toasts.push(ngToast.danger({
+                    dismissButton: true,
+                    dismissOnTimeout: true,
+                    timeout: 4000,
+                    newestOnTop: true,
+                    content: err.message
+                }));
+            });
+    }
+
     /**
      * Retrieves Project from MongoDB.
      * @param projectId

--- a/public/angular-app/add-configuration/add-configuration.html
+++ b/public/angular-app/add-configuration/add-configuration.html
@@ -106,7 +106,7 @@
                                                 {{vm.selectedOffice.name}}
                                             </button>
                                             <ul class="dropdown-menu scrollable-menu-centered" style="padding-right: 0;">
-                                                <li ng-repeat="office in vm.offices" style="padding-right: 5px; padding-left: 5px;">
+                                                <li ng-repeat="office in vm.settings.offices" style="padding-right: 5px; padding-left: 5px;">
                                                         <a href="" ng-click="vm.setOffice(office)" style="padding-left: 0; padding-right: 0;"
                                                             ng-show="vm.selectedType !== 'BIM 360' || office.name === 'All'">
                                                         {{office.name}}

--- a/public/angular-app/add-project/add-project-controller.js
+++ b/public/angular-app/add-project/add-project-controller.js
@@ -3,7 +3,7 @@
  */
 angular.module('MissionControlApp').controller('AddProjectController', AddProjectController);
 
-function AddProjectController(ProjectFactory, $window, ngToast){
+function AddProjectController(ProjectFactory, SettingsFactory, $window, ngToast){
     var vm = this;
     var toasts = [];
     vm.status = '';
@@ -14,6 +14,37 @@ function AddProjectController(ProjectFactory, $window, ngToast){
         name: '',
         number: '',
         office: ''
+    };
+    vm.settings = null;
+
+    getSettings();
+
+    /**
+     * Retrieves Mission Control Settings from the DB.
+     */
+    function getSettings() {
+        SettingsFactory.get()
+            .then(function (response) {
+                if(!response || response.status !== 200) throw { message: 'Unable to retrieve the Settings.'};
+
+                vm.settings = response.data;
+            })
+            .catch(function (err) {
+                toasts.push(ngToast.danger({
+                    dismissButton: true,
+                    dismissOnTimeout: true,
+                    timeout: 4000,
+                    newestOnTop: true,
+                    content: err.message
+                }));
+            });
+    }
+
+    /**
+     * 
+     */
+    vm.setOffice = function(office) {
+        vm.newProject.office = office;
     };
 
     /**

--- a/public/angular-app/add-project/add-project-controller.js
+++ b/public/angular-app/add-project/add-project-controller.js
@@ -44,7 +44,7 @@ function AddProjectController(ProjectFactory, SettingsFactory, $window, ngToast)
      * 
      */
     vm.setOffice = function(office) {
-        vm.newProject.office = office;
+        vm.newProject.office = office.name;
     };
 
     /**

--- a/public/angular-app/add-project/add-project.html
+++ b/public/angular-app/add-project/add-project.html
@@ -79,9 +79,9 @@
 										<span class="caret pull-right" style="margin-top: 8px; margin-bottom: 8px;"></span>
 									</button>
 									<ul class="dropdown-menu scrollable-menu-left">
-										<li ng-repeat="office in vm.settings.offices">
+										<li ng-repeat="office in vm.settings.offices" ng-if="office.name != 'All'">
 											<a href="" ng-click="vm.setOffice(office)" class="no-padding-left no-padding-right">
-												{{office}}
+												{{office.name}}
 											</a>
 										</li>
 									</ul>

--- a/public/angular-app/add-project/add-project.html
+++ b/public/angular-app/add-project/add-project.html
@@ -73,31 +73,19 @@
 								</button>
 							</label>
 							<div class="col-sm-9 no-padding-right">
-								<select class="form-control" id="formOfficeSelect" ng-model="vm.newProject.office">-->
-									<option value="ATL">Atlanta</option>
-									<option value="BEI">Beijing</option>
-									<option value="CHI">Chicago</option>
-									<option value="CAL">Calgary</option>
-									<option value="COL">Columbus</option>
-									<option value="DAL">Dallas</option>
-									<option value="DOH">Doha</option>
-									<option value="DUB">Dubai</option>
-									<option value="HK">Hong Kong</option>
-									<option value="HOU">Houston</option>
-									<option value="KC">Kansas City</option>
-									<option value="LA">Los Angeles</option>
-									<option value="LON">London</option>
-									<option value="NY">New York</option>
-									<option value="OTT">Ottawa</option>
-									<option value="PHI">Philadelphia</option>
-									<option value="SEA">Seattle</option>
-									<option value="SF">San Francisco</option>
-									<option value="SH">Shanghai</option>
-									<option value="STL">St. Louis</option>
-									<option value="TOR">Toronto</option>
-									<option value="TPA">Tampa</option>
-									<option value="WDC">Washington, D.C</option>
-								</select>
+								<div class="btn-group" style="width:100%;">
+									<button class="btn btn-default dropdown-toggle scrollable-menu-centered" data-toggle="dropdown">
+										{{vm.newProject.office}}
+										<span class="caret pull-right" style="margin-top: 8px; margin-bottom: 8px;"></span>
+									</button>
+									<ul class="dropdown-menu scrollable-menu-centered">
+										<li ng-repeat="office in vm.settings.offices">
+											<a href="" ng-click="vm.setOffice(office)" class="no-padding-left no-padding-right">
+												{{office}}
+											</a>
+										</li>
+									</ul>
+								</div>
 							</div>
 						</fieldset>
 						<fieldset class="form-group">

--- a/public/angular-app/add-project/add-project.html
+++ b/public/angular-app/add-project/add-project.html
@@ -74,11 +74,11 @@
 							</label>
 							<div class="col-sm-9 no-padding-right">
 								<div class="btn-group" style="width:100%;">
-									<button class="btn btn-default dropdown-toggle scrollable-menu-centered" data-toggle="dropdown">
+									<button class="btn btn-default dropdown-toggle scrollable-menu-left" data-toggle="dropdown">
 										{{vm.newProject.office}}
 										<span class="caret pull-right" style="margin-top: 8px; margin-bottom: 8px;"></span>
 									</button>
-									<ul class="dropdown-menu scrollable-menu-centered">
+									<ul class="dropdown-menu scrollable-menu-left">
 										<li ng-repeat="office in vm.settings.offices">
 											<a href="" ng-click="vm.setOffice(office)" class="no-padding-left no-padding-right">
 												{{office}}

--- a/public/angular-app/addins/addins-controller.js
+++ b/public/angular-app/addins/addins-controller.js
@@ -3,23 +3,47 @@
  */
 angular.module('MissionControlApp').controller('AddinsController', AddinsController);
 
-function AddinsController(AddinsFactory, UtilityService) {
+function AddinsController(AddinsFactory, UtilityService, SettingsFactory, ngToast) {
     var vm = this;
 
     //region Properties
 
+    var toasts = [];
     vm.SelectedYear = '2019';
     vm.SelectedPlugin = '';
     vm.UserDetails = [];
     vm.YearsAggregate = [];
     vm.MainChartColor = 'steelblue';
     vm.UserChartColor = '#d9534f';
-    vm.officeFilters = UtilityService.getOffices();
     vm.SelectedOffice = 'All'; //TODO: Do we need to define this as a {}?
+    vm.settings = null;
 
     //endregion
 
     // region Methods
+
+    getSettings();
+
+    /**
+     * Retrieves Mission Control Settings from the DB.
+     */
+    function getSettings() {
+        SettingsFactory.get()
+            .then(function (response) {
+                if(!response || response.status !== 200) throw { message: 'Unable to retrieve the Settings.'};
+
+                vm.settings = response.data;
+            })
+            .catch(function (err) {
+                toasts.push(ngToast.danger({
+                    dismissButton: true,
+                    dismissOnTimeout: true,
+                    timeout: 4000,
+                    newestOnTop: true,
+                    content: err.message
+                }));
+            });
+    }
 
     /**
      * Handles user selecting a year filter for all plugin stats.
@@ -68,7 +92,7 @@ function AddinsController(AddinsFactory, UtilityService) {
         // Used for Bar Chart
         var office;
         if (vm.SelectedOffice !== 'All') {
-            var matchedOffice = vm.officeFilters.find(function (filter) { return filter.name === vm.SelectedOffice; });
+            var matchedOffice = vm.settings.offices.find(function (filter) { return filter.name === vm.SelectedOffice; });
             office = matchedOffice.code;
         }
 

--- a/public/angular-app/addins/addins-controller.js
+++ b/public/angular-app/addins/addins-controller.js
@@ -3,7 +3,7 @@
  */
 angular.module('MissionControlApp').controller('AddinsController', AddinsController);
 
-function AddinsController(AddinsFactory, UtilityService, SettingsFactory, ngToast) {
+function AddinsController(AddinsFactory, SettingsFactory, ngToast) {
     var vm = this;
 
     //region Properties

--- a/public/angular-app/addins/addins.html
+++ b/public/angular-app/addins/addins.html
@@ -46,7 +46,7 @@
                             <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu dropdown-menu-right scrollable-menu" style="min-width: 50px;">
-                            <li ng-repeat="office in vm.officeFilters">
+                            <li ng-repeat="office in vm.settings.offices">
                                 <a href="" ng-click="vm.SetOfficeFilter(office)">{{office.name}}</a>
                             </li>
                         </ul>

--- a/public/angular-app/configuration/config-controller.js
+++ b/public/angular-app/configuration/config-controller.js
@@ -4,7 +4,7 @@
 angular.module('MissionControlApp').controller('ConfigController', ConfigController);
 
 function ConfigController($routeParams, FilePathsFactory, ConfigFactory, ProjectFactory, TriggerRecordsFactory,
-                          DTOptionsBuilder, DTColumnBuilder, DTColumnDefBuilder, UtilityService, $window, $uibModal, 
+                          DTOptionsBuilder, DTColumnBuilder, DTColumnDefBuilder, SettingsFactory, UtilityService, $window, $uibModal, 
                           $compile, $scope, ngToast){
 
     //region Init
@@ -22,7 +22,7 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
     vm.fileWarningMsg = '';
     vm.sharedParamWarningMsg = '';
     vm.files = [];
-    vm.offices = UtilityService.getOffices();
+    vm.settings = null;
     vm.selectedOffice = { name: 'All', code: 'All' };
     vm.fileTypes = [ 'All', 'Local', 'Revit Server', 'BIM 360'];
     vm.selectedType = 'All';
@@ -30,6 +30,7 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
     vm.selectedRevitVersion = 'All';
     vm.searchString = '';
 
+    getSettings();
     getSelectedProjectConfiguration(vm.projectId);
     createTable();
 
@@ -487,6 +488,27 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
             //if modal dismissed
         });
     };
+
+    /**
+     * Retrieves Mission Control Settings from the DB.
+     */
+    function getSettings() {
+        SettingsFactory.get()
+            .then(function (response) {
+                if(!response || response.status !== 200) throw { message: 'Unable to retrieve the Settings.'};
+
+                vm.settings = response.data;
+            })
+            .catch(function (err) {
+                toasts.push(ngToast.danger({
+                    dismissButton: true,
+                    dismissOnTimeout: true,
+                    timeout: 4000,
+                    newestOnTop: true,
+                    content: err.message
+                }));
+            });
+    }
 
     //region Utilities
     /**

--- a/public/angular-app/configuration/configuration.html
+++ b/public/angular-app/configuration/configuration.html
@@ -118,11 +118,11 @@
                                                     {{vm.selectedOffice.name}}
                                                 </button>
                                                 <ul class="dropdown-menu scrollable-menu-centered" style="padding-right: 0;">
-                                                    <li ng-repeat="office in vm.offices" style="padding-right: 5px; padding-left: 5px;">
+                                                    <li ng-repeat="office in vm.settings.offices" style="padding-right: 5px; padding-left: 5px;">
                                                         <a href=""
-                                                        ng-click="vm.setOffice(office)"
-                                                        style="padding-left: 0; padding-right: 0;"
-                                                        ng-show="vm.selectedType !== 'BIM 360' || office.name === 'All'">
+                                                           ng-click="vm.setOffice(office)"
+                                                           style="padding-left: 0; padding-right: 0;"
+                                                           ng-show="vm.selectedType !== 'BIM 360' || office.name === 'All'">
                                                             {{office.name}}
                                                         </a>
                                                     </li>

--- a/public/angular-app/data-factory/utility-service.js
+++ b/public/angular-app/data-factory/utility-service.js
@@ -156,40 +156,6 @@ function UtilityService(){
         },
 
         /**
-         * Retrieves a list of all offices and their codes.
-         * @returns {[*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*]}
-         */
-        getOffices: function () {
-            return [
-                {name: 'All', code: 'All'},
-                {name: 'Atlanta', code: ['ATL']},
-                {name: 'Beijing', code: ['BEI']},
-                {name: 'Calgary', code: ['CAL']},
-                {name: 'Chicago', code: ['CHI']},
-                {name: 'Columbus', code: ['COL']},
-                {name: 'Dallas', code: ['DAL']},
-                {name: 'Doha', code: ['DOH']},
-                {name: 'Dubai', code: ['DUB']},
-                {name: 'Hong Kong', code: ['HK']},
-                {name: 'Houston', code: ['HOU']},
-                {name: 'Kansas City', code: ['KC']},
-                {name: 'Los Angeles', code: ['LA']},
-                {name: 'London', code: ['LON']},
-                {name: 'New York', code: ['NY']},
-                {name: 'Ottawa', code: ['OTT']},
-                {name: 'Philadephia', code: ['PHI']},
-                {name: 'Seattle', code: ['SEA']},
-                {name: 'San Francisco', code: ['SF']},
-                {name: 'Shanghai', code: ['SH']},
-                {name: 'St. Louis', code: ['STL', 'BJC']},
-                {name: 'Toronto', code: ['TOR']},
-                {name: 'Tampa', code: ['TPA']},
-                {name: 'Washington DC', code: ['WDC']},
-                {name: 'Undefined', code: ['EMC', 'SDC', 'OSS', 'LD', 'LDC', '']}
-            ];
-        },
-
-        /**
          * Retrieves a list of all Revit versions that we support.
          * @returns {[string,string,string,string,string]}
          */

--- a/public/angular-app/edit-project/edit-project-controller.js
+++ b/public/angular-app/edit-project/edit-project-controller.js
@@ -53,7 +53,7 @@ function EditProjectController($routeParams, $window, ProjectFactory, ConfigFact
      * 
      */
     vm.setOffice = function(office) {
-        vm.selectedProject.office = office;
+        vm.selectedProject.office = office.name;
     };
 
     /**

--- a/public/angular-app/edit-project/edit-project-controller.js
+++ b/public/angular-app/edit-project/edit-project-controller.js
@@ -3,7 +3,7 @@
  */
 angular.module('MissionControlApp').controller('EditProjectController', EditProjectController);
 
-function EditProjectController($routeParams, $window, ProjectFactory, ConfigFactory, ModelsFactory, FilePathsFactory, ngToast, UtilityService){
+function EditProjectController($routeParams, $window, ProjectFactory, ConfigFactory, ModelsFactory, SettingsFactory, FilePathsFactory, ngToast, UtilityService){
     var vm = this;
     var toasts = [];
     var filePaths = []; // variable holding file paths for filter
@@ -21,10 +21,40 @@ function EditProjectController($routeParams, $window, ProjectFactory, ConfigFact
     vm.selectedRange = '7 days';
     vm.availableRanges = ['7 days', '14 days', '28 days', '84 days', 'All'];
     vm.loading = false;
+    vm.settings = null;
 
+    getSettings();
     getOpenTimes(vm.projectId);
 
     //endregion
+
+    /**
+     * Retrieves Mission Control Settings from the DB.
+     */
+    function getSettings() {
+        SettingsFactory.get()
+            .then(function (response) {
+                if(!response || response.status !== 200) throw { message: 'Unable to retrieve the Settings.'};
+
+                vm.settings = response.data;
+            })
+            .catch(function (err) {
+                toasts.push(ngToast.danger({
+                    dismissButton: true,
+                    dismissOnTimeout: true,
+                    timeout: 4000,
+                    newestOnTop: true,
+                    content: err.message
+                }));
+            });
+    }
+
+    /**
+     * 
+     */
+    vm.setOffice = function(office) {
+        vm.selectedProject.office = office;
+    };
 
     /**
      * Filter for activity chart that queries additional data by date range.

--- a/public/angular-app/edit-project/edit-project.html
+++ b/public/angular-app/edit-project/edit-project.html
@@ -71,53 +71,15 @@
 										<span class="caret pull-right" style="margin-top: 8px; margin-bottom: 8px;"></span>
 									</button>
 									<ul class="dropdown-menu scrollable-menu-left">
-										<li ng-repeat="office in vm.settings.offices">
+										<li ng-repeat="office in vm.settings.offices" ng-if="office.name != 'All'">
 											<a href="" ng-click="vm.setOffice(office)" class="no-padding-left no-padding-right">
-												{{office}}
+												{{office.name}}
 											</a>
 										</li>
 									</ul>
 								</div>
 							</div>
 						</fieldset>
-						<!-- <fieldset class="form-group">
-							<label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="formOfficeSelect">
-								Office
-								<button class="fa-wrapper" ng-if="vm.selectedProject.office">
-									<i class="fas fa-check fa-sm" style="color: green;"></i>
-								</button>
-								<button class="fa-wrapper" ng-if="!vm.selectedProject.office">
-									<i class="fas fa-asterisk fa-sm" style="color: red;"></i>
-								</button>
-							</label>
-							<div class="col-sm-9 no-padding-right">
-								<select class="form-control" id="formOfficeSelect" ng-model="vm.selectedProject.office">
-									<option value="ATL">Atlanta</option>
-									<option value="BEI">Beijing</option>
-									<option value="CHI">Chicago</option>
-									<option value="CAL">Calgary</option>
-									<option value="COL">Columbus</option>
-									<option value="DAL">Dallas</option>
-									<option value="DOH">Doha</option>
-									<option value="DUB">Dubai</option>
-									<option value="HK">Hong Kong</option>
-									<option value="HOU">Houston</option>
-									<option value="KC">Kansas City</option>
-									<option value="LA">Los Angeles</option>
-									<option value="LON">London</option>
-									<option value="NY">New York</option>
-									<option value="OTT">Ottawa</option>
-									<option value="PHI">Philadelphia</option>
-									<option value="SEA">Seattle</option>
-									<option value="SF">San Francisco</option>
-									<option value="SH">Shanghai</option>
-									<option value="STL">St. Louis</option>
-									<option value="TOR">Toronto</option>
-									<option value="TPA">Tampa</option>
-									<option value="WDC">Washington, D.C</option>
-								</select>
-							</div>
-						</fieldset> -->
 						<fieldset class="form-group">
 							<label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="formStreet">Street Address</label>
 							<div class="col-sm-9 no-padding-right">

--- a/public/angular-app/edit-project/edit-project.html
+++ b/public/angular-app/edit-project/edit-project.html
@@ -65,6 +65,32 @@
 								</button>
 							</label>
 							<div class="col-sm-9 no-padding-right">
+								<div class="btn-group" style="width:100%;">
+									<button class="btn btn-default dropdown-toggle scrollable-menu-left" data-toggle="dropdown">
+										{{vm.selectedProject.office}}
+										<span class="caret pull-right" style="margin-top: 8px; margin-bottom: 8px;"></span>
+									</button>
+									<ul class="dropdown-menu scrollable-menu-left">
+										<li ng-repeat="office in vm.settings.offices">
+											<a href="" ng-click="vm.setOffice(office)" class="no-padding-left no-padding-right">
+												{{office}}
+											</a>
+										</li>
+									</ul>
+								</div>
+							</div>
+						</fieldset>
+						<!-- <fieldset class="form-group">
+							<label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="formOfficeSelect">
+								Office
+								<button class="fa-wrapper" ng-if="vm.selectedProject.office">
+									<i class="fas fa-check fa-sm" style="color: green;"></i>
+								</button>
+								<button class="fa-wrapper" ng-if="!vm.selectedProject.office">
+									<i class="fas fa-asterisk fa-sm" style="color: red;"></i>
+								</button>
+							</label>
+							<div class="col-sm-9 no-padding-right">
 								<select class="form-control" id="formOfficeSelect" ng-model="vm.selectedProject.office">
 									<option value="ATL">Atlanta</option>
 									<option value="BEI">Beijing</option>
@@ -91,7 +117,7 @@
 									<option value="WDC">Washington, D.C</option>
 								</select>
 							</div>
-						</fieldset>
+						</fieldset> -->
 						<fieldset class="form-group">
 							<label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="formStreet">Street Address</label>
 							<div class="col-sm-9 no-padding-right">

--- a/public/angular-app/file-paths/file-paths.html
+++ b/public/angular-app/file-paths/file-paths.html
@@ -24,7 +24,7 @@
                             <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu scrollable-menu" style="min-width: 50px;">
-                            <li ng-repeat="office in vm.offices">
+                            <li ng-repeat="office in vm.settings.offices">
                                 <a href="" ng-click="vm.setOffice(office)">{{office.name}}</a>
                             </li>
                         </ul>

--- a/public/angular-app/file-paths/file-paths.js
+++ b/public/angular-app/file-paths/file-paths.js
@@ -4,16 +4,17 @@
 angular.module('MissionControlApp').controller('FilePathsController', FilePathsController);
 
 function FilePathsController(FilePathsFactory, UtilityService, DTOptionsBuilder, DTColumnBuilder, ngToast, $location, $scope, $compile,
-                             $uibModal){
+                             $uibModal, SettingsFactory){
     var vm = this;
     var toasts = [];
     vm.files = [];
     vm.revitVersions = UtilityService.getRevitVersions();
     vm.selectedRevitVersion = 'All';
-    vm.offices = UtilityService.getOffices();
+    vm.settings = null;
     vm.selectedOffice = { name: 'All', code: 'All' };
     vm.disabledFilter = false;
 
+    getSettings();
     createTable();
 
     //region Handlers
@@ -108,6 +109,27 @@ function FilePathsController(FilePathsFactory, UtilityService, DTOptionsBuilder,
     //endregion
 
     //region Utilities
+
+    /**
+     * Retrieves Mission Control Settings from the DB.
+     */
+    function getSettings() {
+        SettingsFactory.get()
+            .then(function (response) {
+                if(!response || response.status !== 200) throw { message: 'Unable to retrieve the Settings.'};
+
+                vm.settings = response.data;
+            })
+            .catch(function (err) {
+                toasts.push(ngToast.danger({
+                    dismissButton: true,
+                    dismissOnTimeout: true,
+                    timeout: 4000,
+                    newestOnTop: true,
+                    content: err.message
+                }));
+            });
+    }
 
     /**
      * Initiates File Paths table.

--- a/public/angular-app/filters/filters.js
+++ b/public/angular-app/filters/filters.js
@@ -2,5 +2,5 @@ angular.module('MissionControlApp')
     .filter('split', function() {
         return function(input) {
             return input.replace(/^.*[\\\/]/, '').slice(0, -4); //removed file extension
-        }
+        };
     });

--- a/public/angular-app/settings/settings-controller.js
+++ b/public/angular-app/settings/settings-controller.js
@@ -17,7 +17,7 @@ function SettingsController(SettingsFactory, ngToast, $route){
      * @constructor
      */
     vm.AddOffice = function (arr) {
-        if(vm.office.name === null || vm.office.code === null) return;
+        if(!vm.office.name.trim() || !vm.office.code.trim()) return;
 
         arr.push({name: vm.office.name, code: vm.office.code.split(',')});
         vm.office = { name: null, code: null };
@@ -53,7 +53,7 @@ function SettingsController(SettingsFactory, ngToast, $route){
      * Makes sure that all fields that are required are filled in. 
      */
     vm.verifyForm = function () {
-        return vm.settings === null || vm.settings.offices.length <= 1;
+        return !vm.settings || vm.settings.offices.length <= 1;
     };
 
     /**
@@ -62,7 +62,7 @@ function SettingsController(SettingsFactory, ngToast, $route){
     vm.update = function () {
         // (Konrad) For the filtering purposes we will always need the "All" item.
         // It will be ignored in some dropdowns like the EditProject, NewProject etc.
-        if (vm.settings.offices.find(function(item) { return item.name === 'All'; }) === undefined) {
+        if (!vm.settings.offices.some(function(item) { return item.name === 'All'; })) {
             vm.settings.offices.push({ name:'All', code:['All'] });
         }
 

--- a/public/angular-app/settings/settings-controller.js
+++ b/public/angular-app/settings/settings-controller.js
@@ -7,13 +7,58 @@ function SettingsController(SettingsFactory, ngToast, $route){
     var vm = this;
     var toasts = [];
     vm.settings = null;
+    vm.office = null;
 
     getSettings();
 
+    /**
+     * Adds Office Location to the list.
+     * @param arr
+     * @constructor
+     */
+    vm.AddOfficeName = function (arr) {
+        if(vm.office === null) return;
+
+        arr.push(vm.office);
+        vm.office = null;
+    };
+
+    /**
+     * Triggers AddOfficeName function on Enter key.
+     * @param event
+     * @param arr
+     * @param action
+     */
+    vm.onEnter = function (event, arr, action) {
+        if(event.which !== 13) return;
+
+        switch (action){
+            case 'OfficeName':
+                vm.AddOfficeName(arr);
+                break;
+        }
+    };
+
+    /**
+     * Removes office name from the list.
+     * @param arr
+     * @param index
+     * @constructor
+     */
+    vm.RemoveName = function (arr, index) {
+        arr.splice(index, 1);
+    };
+
+    /**
+     * 
+     */
     vm.verifyForm = function () {
         // TODO: Handle form validation.
     };
 
+    /**
+     * 
+     */
     vm.update = function () {
         SettingsFactory.update(vm.settings)
             .then(function(response){

--- a/public/angular-app/settings/settings-controller.js
+++ b/public/angular-app/settings/settings-controller.js
@@ -7,7 +7,7 @@ function SettingsController(SettingsFactory, ngToast, $route){
     var vm = this;
     var toasts = [];
     vm.settings = null;
-    vm.office = null;
+    vm.office = { name: null, code: null };
 
     getSettings();
 
@@ -16,11 +16,11 @@ function SettingsController(SettingsFactory, ngToast, $route){
      * @param arr
      * @constructor
      */
-    vm.AddOfficeName = function (arr) {
-        if(vm.office === null) return;
+    vm.AddOffice = function (arr) {
+        if(vm.office.name === null || vm.office.code === null) return;
 
-        arr.push(vm.office);
-        vm.office = null;
+        arr.push({name: vm.office.name, code: vm.office.code.split(',')});
+        vm.office = { name: null, code: null };
     };
 
     /**
@@ -33,8 +33,8 @@ function SettingsController(SettingsFactory, ngToast, $route){
         if(event.which !== 13) return;
 
         switch (action){
-            case 'OfficeName':
-                vm.AddOfficeName(arr);
+            case 'Office':
+                vm.AddOffice(arr);
                 break;
         }
     };
@@ -45,21 +45,27 @@ function SettingsController(SettingsFactory, ngToast, $route){
      * @param index
      * @constructor
      */
-    vm.RemoveName = function (arr, index) {
+    vm.Remove = function (arr, index) {
         arr.splice(index, 1);
     };
 
     /**
-     * 
+     * Makes sure that all fields that are required are filled in. 
      */
     vm.verifyForm = function () {
-        // TODO: Handle form validation.
+        return vm.settings === null || vm.settings.offices.length <= 1;
     };
 
     /**
      * 
      */
     vm.update = function () {
+        // (Konrad) For the filtering purposes we will always need the "All" item.
+        // It will be ignored in some dropdowns like the EditProject, NewProject etc.
+        if (vm.settings.offices.find(function(item) { return item.name === 'All'; }) === undefined) {
+            vm.settings.offices.push({ name:'All', code:['All'] });
+        }
+
         SettingsFactory.update(vm.settings)
             .then(function(response){
                 if(!response || response.status !== 201) throw { message: 'Unable to update Settings.' };

--- a/public/angular-app/settings/settings.html
+++ b/public/angular-app/settings/settings.html
@@ -36,7 +36,7 @@
                        </fieldset>
                        
                        <fieldset class="form-group">
-                        <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="offices">
+                        <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="officeName">
                             Office Locations
                             <button class="fa-wrapper" ng-if="vm.settings.offices.length > 0">
                                 <i class="fas fa-check fa-sm" style="color: green;"></i>
@@ -47,27 +47,36 @@
                         </label>
                         <div class="col-sm-9 no-padding-right">
                             <div class="col-md-3 no-padding-left">
+                                <input id="officeName"
+                                       type="text"
+                                       placeholder="Add Office Location..."
+                                       class="form-control input-sm"
+                                       ng-model="vm.office.name"
+                                       ng-keypress="vm.onEnter($event, vm.settings.offices, 'Office')">
+                            </div>
+                            <div class="col-md-3 no-padding-left">
                                 <div class="input-group">
-                                    <input id="offices"
+                                    <input id="officeCode"
                                            type="text"
-                                           placeholder="Add Office..."
+                                           placeholder="Add Office Code..."
                                            class="form-control input-sm"
-                                           ng-model="vm.office"
-                                           ng-keypress="vm.onEnter($event, vm.settings.offices, 'OfficeName')">
+                                           ng-model="vm.office.code"
+                                           ng-keypress="vm.onEnter($event, vm.settings.offices, 'Office')">
                                     <span class="input-group-btn">
                                         <button class="btn btn-default btn-sm"
-                                            type="button"
-                                            ng-click="vm.AddOfficeName(vm.settings.offices)">
+                                                type="button"
+                                                ng-click="vm.AddOfficeName(vm.settings.offices)">
                                             <i class="fas fa-plus"></i>
                                         </button>
                                     </span>
                                 </div>
                             </div>
-                            <div class="col-md-7">
+                            <div class="col-md-6">
                                     <span ng-repeat="office in vm.settings.offices track by $index"
+                                          ng-if="office.name != 'All'"
                                           class="btn btn-default btn-sm"
-                                          ng-click="vm.RemoveName(vm.settings.offices, $index)">
-                                        {{office}}
+                                          ng-click="vm.Remove(vm.settings.offices, $index)">
+                                        {{office.name}} - [{{office.code.join(",")}}]
                                     </span>
                             </div>
                         </div>

--- a/public/angular-app/settings/settings.html
+++ b/public/angular-app/settings/settings.html
@@ -34,168 +34,44 @@
                                </div>
                            </div>
                        </fieldset>
-                       <!-- <fieldset class="form-group">
-                           <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="formProjectName">
-                               Project Name
-                               <button class="fa-wrapper" ng-if="vm.newProject.name">
-                                   <i class="fas fa-check fa-sm" style="color: green;"></i>
-                               </button>
-                               <button class="fa-wrapper" ng-if="!vm.newProject.name">
-                                   <i class="fas fa-asterisk fa-sm" style="color: red;"></i>
-                               </button>
-                           </label>
-                           <div class="col-sm-9 no-padding-right">
-                               <input type="text"
-                                   name="pName"
-                                   class="form-control"
-                                   id="formProjectName"
-                                   placeholder="Project Name"
-                                   ng-model="vm.newProject.name" required>
-                               <div ng-show="form.$submitted || form.pName.$touched">
-                                   <div ng-show="form.pName.$error.required" class="text-danger">(*) Project Name is required.</div>
-                               </div>
-                               <div ng-show="vm.newProject.name.length > 35">
-                                   <div class="text-danger">(*) Project Name is too long.</div>
-                               </div>
-                           </div>
-                       </fieldset>
+                       
                        <fieldset class="form-group">
-                           <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="formOfficeSelect">
-                               Office
-                               <button class="fa-wrapper" ng-if="vm.newProject.office">
-                                   <i class="fas fa-check fa-sm" style="color: green;"></i>
-                               </button>
-                               <button class="fa-wrapper" ng-if="!vm.newProject.office">
-                                   <i class="fas fa-asterisk fa-sm" style="color: red;"></i>
-                               </button>
-                           </label>
-                           <div class="col-sm-9 no-padding-right">
-                               <select class="form-control" id="formOfficeSelect" ng-model="vm.newProject.office">
-                                   <option value="ATL">Atlanta</option>
-                                   <option value="BEI">Beijing</option>
-                                   <option value="CHI">Chicago</option>
-                                   <option value="CAL">Calgary</option>
-                                   <option value="COL">Columbus</option>
-                                   <option value="DAL">Dallas</option>
-                                   <option value="DOH">Doha</option>
-                                   <option value="DUB">Dubai</option>
-                                   <option value="HK">Hong Kong</option>
-                                   <option value="HOU">Houston</option>
-                                   <option value="KC">Kansas City</option>
-                                   <option value="LA">Los Angeles</option>
-                                   <option value="LON">London</option>
-                                   <option value="NY">New York</option>
-                                   <option value="OTT">Ottawa</option>
-                                   <option value="PHI">Philadelphia</option>
-                                   <option value="SEA">Seattle</option>
-                                   <option value="SF">San Francisco</option>
-                                   <option value="SH">Shanghai</option>
-                                   <option value="STL">St. Louis</option>
-                                   <option value="TOR">Toronto</option>
-                                   <option value="TPA">Tampa</option>
-                                   <option value="WDC">Washington, D.C</option>
-                               </select>
-                           </div>
-                       </fieldset>
-                       <fieldset class="form-group">
-                           <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="formStreet">Street Address</label>
-                           <div class="col-sm-9 no-padding-right">
-                               <input type="text"
-                                      class="form-control"
-                                      id="formStreet"
-                                      placeholder="Street address, P.O. box, company name"
-                                      ng-model="vm.newProject.address.street1">
-                           </div>
-                       </fieldset>
-                       <fieldset class="form-group">
-                           <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="formStreet2">Street Address2</label>
-                           <div class="col-sm-9 no-padding-right">
-                               <input type="text"
-                                      class="form-control"
-                                      id="formStreet2"
-                                      placeholder="Apartment, suite, unit, building, floor, etc."
-                                      ng-model="vm.newProject.address.street2">
-                           </div>
-                       </fieldset>
-                       <fieldset class="form-group">
-                           <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="formCity">City</label>
-                           <div class="col-sm-9 no-padding-right">
-                               <input type="text"
-                                      class="form-control"
-                                      id="formCity"
-                                      ng-model="vm.newProject.address.city">
-                           </div>
-                       </fieldset>
-                       <fieldset class="form-group">
-                           <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="formState">State</label>
-                           <div class="col-sm-9 no-padding-right">
-                               <select class="form-control" id="formState" ng-model="vm.newProject.address.state">
-                                   <option value="AL">Alabama</option>
-                                   <option value="AK">Alaska</option>
-                                   <option value="AZ">Arizona</option>
-                                   <option value="AR">Arkansas</option>
-                                   <option value="CA">California</option>
-                                   <option value="CO">Colorado</option>
-                                   <option value="CT">Connecticut</option>
-                                   <option value="DE">Delaware</option>
-                                   <option value="DC">District Of Columbia</option>
-                                   <option value="FL">Florida</option>
-                                   <option value="GA">Georgia</option>
-                                   <option value="HI">Hawaii</option>
-                                   <option value="ID">Idaho</option>
-                                   <option value="IL">Illinois</option>
-                                   <option value="IN">Indiana</option>
-                                   <option value="IA">Iowa</option>
-                                   <option value="KS">Kansas</option>
-                                   <option value="KY">Kentucky</option>
-                                   <option value="LA">Louisiana</option>
-                                   <option value="ME">Maine</option>
-                                   <option value="MD">Maryland</option>
-                                   <option value="MA">Massachusetts</option>
-                                   <option value="MI">Michigan</option>
-                                   <option value="MN">Minnesota</option>
-                                   <option value="MS">Mississippi</option>
-                                   <option value="MO">Missouri</option>
-                                   <option value="MT">Montana</option>
-                                   <option value="NE">Nebraska</option>
-                                   <option value="NV">Nevada</option>
-                                   <option value="NH">New Hampshire</option>
-                                   <option value="NJ">New Jersey</option>
-                                   <option value="NM">New Mexico</option>
-                                   <option value="NY">New York</option>
-                                   <option value="NC">North Carolina</option>
-                                   <option value="ND">North Dakota</option>
-                                   <option value="OH">Ohio</option>
-                                   <option value="OK">Oklahoma</option>
-                                   <option value="OR">Oregon</option>
-                                   <option value="PA">Pennsylvania</option>
-                                   <option value="RI">Rhode Island</option>
-                                   <option value="SC">South Carolina</option>
-                                   <option value="SD">South Dakota</option>
-                                   <option value="TN">Tennessee</option>
-                                   <option value="TX">Texas</option>
-                                   <option value="UT">Utah</option>
-                                   <option value="VT">Vermont</option>
-                                   <option value="VA">Virginia</option>
-                                   <option value="WA">Washington</option>
-                                   <option value="WV">West Virginia</option>
-                                   <option value="WI">Wisconsin</option>
-                                   <option value="WY">Wyoming</option>
-                               </select>
-                           </div>
-                       </fieldset>
-                       <fieldset class="form-group">
-                           <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="formZip">Zip Code</label>
-                           <div class="col-sm-9 no-padding-right">
-                               <input type="text" class="form-control" id="formZip" ng-model="vm.newProject.address.zipCode">
-                           </div>
-                       </fieldset>
-                       <fieldset class="form-group">
-                           <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="formCountry">Country</label>
-                           <div class="col-sm-9 no-padding-right">
-                               <input type="text" class="form-control" id="formCountry" ng-model="vm.newProject.address.country">
-                           </div>
-                       </fieldset> -->
+                        <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="offices">
+                            Office Locations
+                            <button class="fa-wrapper" ng-if="vm.settings.offices.length > 0">
+                                <i class="fas fa-check fa-sm" style="color: green;"></i>
+                            </button>
+                            <button class="fa-wrapper" ng-if="!vm.settings.offices.length > 0">
+                                <i class="fas fa-asterisk fa-sm" style="color: red;"></i>
+                            </button>
+                        </label>
+                        <div class="col-sm-9 no-padding-right">
+                            <div class="col-md-3 no-padding-left">
+                                <div class="input-group">
+                                    <input id="offices"
+                                           type="text"
+                                           placeholder="Add Office..."
+                                           class="form-control input-sm"
+                                           ng-model="vm.office"
+                                           ng-keypress="vm.onEnter($event, vm.settings.offices, 'OfficeName')">
+                                    <span class="input-group-btn">
+                                        <button class="btn btn-default btn-sm"
+                                            type="button"
+                                            ng-click="vm.AddOfficeName(vm.settings.offices)">
+                                            <i class="fas fa-plus"></i>
+                                        </button>
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="col-md-7">
+                                    <span ng-repeat="office in vm.settings.offices track by $index"
+                                          class="btn btn-default btn-sm"
+                                          ng-click="vm.RemoveName(vm.settings.offices, $index)">
+                                        {{office}}
+                                    </span>
+                            </div>
+                        </div>
+                    </fieldset>
                    </form>
                    <button id="submitButton"
                            type="submit"

--- a/public/angular-app/settings/settings.html
+++ b/public/angular-app/settings/settings.html
@@ -71,10 +71,11 @@
                                     </span>
                                 </div>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-6 no-padding">
                                     <span ng-repeat="office in vm.settings.offices track by $index"
                                           ng-if="office.name != 'All'"
                                           class="btn btn-default btn-sm"
+                                          style="margin-left: 1px; margin-right: 1px; margin-bottom: 2px;"
                                           ng-click="vm.Remove(vm.settings.offices, $index)">
                                         {{office.name}} - [{{office.code.join(",")}}]
                                     </span>

--- a/public/angular-app/settings/settings.html
+++ b/public/angular-app/settings/settings.html
@@ -65,7 +65,7 @@
                                     <span class="input-group-btn">
                                         <button class="btn btn-default btn-sm"
                                                 type="button"
-                                                ng-click="vm.AddOfficeName(vm.settings.offices)">
+                                                ng-click="vm.AddOffice(vm.settings.offices)">
                                             <i class="fas fa-plus"></i>
                                         </button>
                                     </span>

--- a/public/angular-app/zombie-logs/zombie-logs.html
+++ b/public/angular-app/zombie-logs/zombie-logs.html
@@ -64,7 +64,7 @@
                                         <span class="caret"></span>
                                     </button>
                                     <ul class="dropdown-menu scrollable-menu">
-                                        <li ng-repeat="office in vm.officeFilters">
+                                        <li ng-repeat="office in vm.settings.offices">
                                             <a href="" ng-click="vm.SetOfficeFilter(office)">{{office.name}}</a>
                                         </li>
                                     </ul>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -159,6 +159,17 @@ p.normal {
   transform: translate(-50%, 0);
 }
 
+.scrollable-menu-left{
+  height: auto;
+  max-height: 195px;
+  overflow-x: hidden;
+  width:100%;
+  right: auto;
+  text-align: left;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 /*Scrollable menu for long lists*/
 .scrollable-menu {
   height: auto;


### PR DESCRIPTION
### READY

This will add ability to only select offices that user added to global settings. That way we get rid of hard coded list of office locations that was specific to HOK. 

Since office locations have two functionctions:
- project setup
- filtering for charts

...I made a change to the schema where we define each location as 
```
{name: string, code: [string]}
```
That way we can use the names for project dropdowns but the code when we are filtering charts. I updated all of the locations where I think we used the offices, removed the previous utilities method. Now we just have to fix the other side of this which is the Revit methods that actually publish office info when submitting logs for addins etc. I will do that in a different PR though so we can keep them focused. 