### PR TITLE
Feature/add local path

### DIFF
--- a/app/controller/filepaths.js
+++ b/app/controller/filepaths.js
@@ -293,6 +293,7 @@ FilePathsService = {
         var disabled = req.body['disabled'];
         var unassigned = req.body['unassigned'];
         var fileType = req.body['fileType'];
+        var localPathRgx = req.body['localPathRgx'];
         var query = {};
 
         // (Konrad) Always check if disabled.
@@ -359,7 +360,10 @@ FilePathsService = {
                     var filePath = item.centralPath.toLowerCase();
                     switch(fileType){
                         case 'Local': 
-                            return filePath.lastIndexOf('\\\\group\\hok\\', 0) === 0;
+                            return localPathRgx.some(function(pattern) { 
+                                var rgx = new RegExp(pattern, 'i');
+                                return rgx.test(filePath); 
+                            });
                         case 'BIM 360':
                             return filePath.lastIndexOf('bim 360://', 0) === 0;
                         case 'Revit Server':

--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -21,10 +21,6 @@ var settingsSchema = new mongoose.Schema(
             default: 'Settings',
             set: function () { return 'Settings'; }
         },
-        httpAddress: {
-            type: String,
-            default: 'http://missioncontrol.hok.com'
-        },
         offices: {
             type: [officeSchema],
             default: [
@@ -46,7 +42,8 @@ var settingsSchema = new mongoose.Schema(
                 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia',
                 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
             ]
-        }
+        },
+        localPathRgx: [String]
     }
 );
 

--- a/public/angular-app/configuration/config-controller.js
+++ b/public/angular-app/configuration/config-controller.js
@@ -148,7 +148,6 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
             })
             .catch(function (err) {
                 vm.loading = false;
-                console.log(err);
                 toasts.push(ngToast.danger({
                     dismissButton: true,
                     dismissOnTimeout: true,
@@ -256,7 +255,11 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
 
         // (Konrad) Everything is lower case to make matching easier.
         // Checks if file path is one of the three (3) approved types.
-        var isLocal = filePath.lastIndexOf('\\\\group\\hok\\', 0) === 0;
+        var isLocal = vm.settings.localPathRgx.some(function(pattern) { 
+            var rgx = new RegExp(pattern, 'i');
+            return rgx.test(filePath); 
+        });
+        // var isLocal = filePath.lastIndexOf('\\\\group\\hok\\', 0) === 0;
         var isBim360 = filePath.lastIndexOf('bim 360://', 0) === 0;
         var isRevitServer = filePath.lastIndexOf('rsn://', 0) === 0;
 
@@ -273,13 +276,13 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
 
         var uri = UtilityService.getHttpSafeFilePath(filePath);
         ConfigFactory.getByCentralPath(uri)
-            .then(function(response){
+            .then(function(response) {
                 if(!response || response.status !== 200) throw response;
 
                 var configFound = response.data;
                 var configNames = '';
                 var configMatched = false;
-                if(configFound.length > 0){
+                if(configFound.length > 0) {
                     //find an exact match from text search result
                     for(var i = 0; i < configFound.length; i++) {
                         var config = configFound[i];
@@ -293,8 +296,9 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
                         }
                     }
                 }
-                if(configMatched){
+                if(configMatched) {
                     vm.fileWarningMsg = 'Warning! File already exists in other configurations.\n' + configNames;
+                    throw { message: 'File already exists in other configurations.\n' + configNames };
                 } else {
                     var file1 = { centralPath: filePath };
                     vm.selectedConfig.files.push(file1);
@@ -329,7 +333,6 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
                 }));
             })
             .catch(function (err) {
-                console.log(err);
                 toasts.push(ngToast.danger({
                     dismissButton: true,
                     dismissOnTimeout: true,
@@ -344,7 +347,7 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
      * Removes selected file from MongoDB.
      * @param filePath
      */
-    vm.deleteFile = function(filePath){
+    vm.deleteFile = function(filePath) {
         for (var i = 0; i < vm.selectedConfig.files.length; i++) {
             var file =  vm.selectedConfig.files[i];
             if (file.centralPath.toLowerCase() === filePath.toLowerCase()) {
@@ -376,7 +379,6 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
                         }));
                     })
                     .catch(function (err) {
-                        console.log(err);
                         toasts.push(ngToast.danger({
                             dismissButton: true,
                             dismissOnTimeout: true,
@@ -417,7 +419,6 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
                 }
             })
             .catch(function (err) {
-                console.log(err);
                 toasts.push(ngToast.danger({
                     dismissButton: true,
                     dismissOnTimeout: true,
@@ -459,8 +460,7 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
                 if(!response || response.status !== 201) throw response;
                 $window.location.reload();
             })
-            .catch(function (err) {
-                console.log(err);
+            .catch(function () {
                 toasts.push(ngToast.danger({
                     dismissButton: true,
                     dismissOnTimeout: true,
@@ -481,7 +481,7 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
             templateUrl: 'angular-app/configuration/file-path-help.html',
             controller: 'FilePathHelpController as vm',
             size: size
-        }).result.then(function(request){
+        }).result.then(function(){
             //model closed
 
         }).catch(function(){
@@ -532,7 +532,6 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
                 }
             })
             .catch(function (err) {
-                console.log(err);
                 toasts.push(ngToast.danger({
                     dismissButton: true,
                     dismissOnTimeout: true,
@@ -582,6 +581,7 @@ function ConfigController($routeParams, FilePathsFactory, ConfigFactory, Project
                     d.fileType  = vm.selectedType;
                     d.disabled = false;
                     d.unassigned = true;
+                    d.localPathRgx = !vm.settings ? null : vm.settings.localPathRgx;
                 }
             })
             .withDataProp('data')

--- a/public/angular-app/file-paths/file-paths.js
+++ b/public/angular-app/file-paths/file-paths.js
@@ -120,11 +120,6 @@ function FilePathsController(FilePathsFactory, UtilityService, DTOptionsBuilder,
 
                 vm.settings = response.data;
             })
-            .then(function () {
-                // Only after vm.settings were set we can properly load all file paths.
-                // We should refresh the table at this point.
-                reloadTable();
-            })
             .catch(function (err) {
                 toasts.push(ngToast.danger({
                     dismissButton: true,

--- a/public/angular-app/file-paths/file-paths.js
+++ b/public/angular-app/file-paths/file-paths.js
@@ -14,8 +14,8 @@ function FilePathsController(FilePathsFactory, UtilityService, DTOptionsBuilder,
     vm.selectedOffice = { name: 'All', code: 'All' };
     vm.disabledFilter = false;
 
-    getSettings();
     createTable();
+    getSettings();
 
     //region Handlers
 
@@ -120,6 +120,11 @@ function FilePathsController(FilePathsFactory, UtilityService, DTOptionsBuilder,
 
                 vm.settings = response.data;
             })
+            .then(function () {
+                // Only after vm.settings were set we can properly load all file paths.
+                // We should refresh the table at this point.
+                reloadTable();
+            })
             .catch(function (err) {
                 toasts.push(ngToast.danger({
                     dismissButton: true,
@@ -144,6 +149,7 @@ function FilePathsController(FilePathsFactory, UtilityService, DTOptionsBuilder,
                     d.revitVersion = vm.selectedRevitVersion;
                     d.office = vm.selectedOffice;
                     d.disabled = vm.disabledFilter;
+                    d.localPathRgx = !vm.settings ? null : vm.settings.localPathRgx;
                 }
             })
             .withDataProp('data')

--- a/public/angular-app/settings/settings-controller.js
+++ b/public/angular-app/settings/settings-controller.js
@@ -9,6 +9,7 @@ function SettingsController(SettingsFactory, ngToast, $route){
     vm.settings = null;
     vm.office = { name: null, code: null };
     vm.state = null;
+    vm.localFilePath = null;
 
     getSettings();
 
@@ -25,13 +26,23 @@ function SettingsController(SettingsFactory, ngToast, $route){
     };
 
     /**
-     * 
+     * Adds State/Region name to the list.
      */
     vm.AddState = function (arr) {
-        if(vm.state === null) return;
+        if(!vm.state.trim()) return;
 
         arr.push(vm.state);
         vm.state = null;
+    };
+
+    /**
+     * Adds Local File Path Regex to the list.
+     */
+    vm.AddLocalFile = function (arr) {
+        if(!vm.localFilePath.trim()) return;
+
+        arr.push(vm.localFilePath);
+        vm.localFilePath = null;
     };
 
     /**
@@ -50,6 +61,8 @@ function SettingsController(SettingsFactory, ngToast, $route){
             case 'State':
                 vm.AddState(arr);
                 break;
+            case 'LocalFilePath':
+                vm.AddLocalFilePath
         }
     };
 

--- a/public/angular-app/settings/settings-controller.js
+++ b/public/angular-app/settings/settings-controller.js
@@ -6,6 +6,7 @@ angular.module('MissionControlApp').controller('SettingsController', SettingsCon
 function SettingsController(SettingsFactory, ngToast, $route){
     var vm = this;
     var toasts = [];
+    
     vm.settings = null;
     vm.office = { name: null, code: null };
     vm.state = null;
@@ -14,35 +15,29 @@ function SettingsController(SettingsFactory, ngToast, $route){
     getSettings();
 
     /**
-     * Adds Office Location to the list.
-     * @param arr
-     * @constructor
+     * 
      */
-    vm.AddOffice = function (arr) {
-        if(!vm.office.name.trim() || !vm.office.code.trim()) return;
+    vm.addValue = function (arr, action) {
+        switch (action){
+            case 'Office':
+                if(!vm.office.name.trim() || !vm.office.code.trim()) return;
 
-        arr.push({name: vm.office.name, code: vm.office.code.split(',')});
-        vm.office = { name: null, code: null };
-    };
+                arr.push({name: vm.office.name, code: vm.office.code.split(',')});
+                vm.office = { name: null, code: null };
+                break;
+            case 'State':
+                if(!vm.state.trim()) return;
 
-    /**
-     * Adds State/Region name to the list.
-     */
-    vm.AddState = function (arr) {
-        if(!vm.state.trim()) return;
+                arr.push(vm.state);
+                vm.state = null;
+                break;
+            case 'LocalFilePath':
+                if(!vm.localFilePath.trim()) return;
 
-        arr.push(vm.state);
-        vm.state = null;
-    };
-
-    /**
-     * Adds Local File Path Regex to the list.
-     */
-    vm.AddLocalFile = function (arr) {
-        if(!vm.localFilePath.trim()) return;
-
-        arr.push(vm.localFilePath);
-        vm.localFilePath = null;
+                arr.push(vm.localFilePath);
+                vm.localFilePath = null;
+                break;
+        }
     };
 
     /**
@@ -54,16 +49,7 @@ function SettingsController(SettingsFactory, ngToast, $route){
     vm.onEnter = function (event, arr, action) {
         if(event.which !== 13) return;
 
-        switch (action){
-            case 'Office':
-                vm.AddOffice(arr);
-                break;
-            case 'State':
-                vm.AddState(arr);
-                break;
-            case 'LocalFilePath':
-                vm.AddLocalFilePath
-        }
+        vm.addValue(arr, action);
     };
 
     /**

--- a/public/angular-app/settings/settings.html
+++ b/public/angular-app/settings/settings.html
@@ -42,7 +42,7 @@
                                     <span class="input-group-btn">
                                         <button class="btn btn-default btn-sm"
                                                 type="button"
-                                                ng-click="vm.AddOffice(vm.settings.offices)">
+                                                ng-click="vm.addValue(vm.settings.offices, 'Office')">
                                             <i class="fas fa-plus"></i>
                                         </button>
                                     </span>
@@ -81,7 +81,7 @@
                                         <span class="input-group-btn">
                                             <button class="btn btn-default btn-sm"
                                                     type="button"
-                                                    ng-click="vm.AddState(vm.settings.states)">
+                                                    ng-click="vm.addValue(vm.settings.states, 'State')">
                                                 <i class="fas fa-plus"></i>
                                             </button>
                                         </span>
@@ -119,7 +119,7 @@
                                         <span class="input-group-btn">
                                             <button class="btn btn-default btn-sm"
                                                     type="button"
-                                                    ng-click="vm.AddLocalFile(vm.settings.localPathRgx)">
+                                                    ng-click="vm.addValue(vm.settings.localPathRgx, 'LocalFilePath')">
                                                 <i class="fas fa-plus"></i>
                                             </button>
                                         </span>

--- a/public/angular-app/settings/settings.html
+++ b/public/angular-app/settings/settings.html
@@ -13,28 +13,6 @@
                <div class="panel-body">
                    <form class ="form-horizontal">
                         <fieldset class="form-group">
-                           <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="httpAddress">
-                               Website Address
-                               <button class="fa-wrapper" ng-if="vm.settings.httpAddress">
-                                   <i class="fas fa-check fa-sm" style="color: green;"></i>
-                               </button>
-                               <button class="fa-wrapper" ng-if="!vm.settings.httpAddress">
-                                   <i class="fas fa-asterisk fa-sm" style="color: red;"></i>
-                               </button>
-                           </label>
-                           <div class="col-sm-9 no-padding-right">
-                               <input type="text"
-                                   name="link"
-                                   class="form-control"
-                                   id="httpAddress"
-                                   placeholder="www.missioncontrol.com"
-                                   ng-model="vm.settings.httpAddress" required>
-                               <div ng-show="form.$submitted || form.link.$touched">
-                                   <div ng-show="form.link.$error.required" class="text-danger">(*) Website Address is required.</div>
-                               </div>
-                           </div>
-                        </fieldset>
-                        <fieldset class="form-group">
                         <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="officeName">
                             Office Locations
                             <button class="fa-wrapper" ng-if="vm.settings.offices.length > 0">
@@ -118,7 +96,45 @@
                                     </span>
                                 </div>
                             </div>
-                            </fieldset>
+                        </fieldset>
+                        <fieldset class="form-group">
+                            <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="localPath">
+                                Local File Path Regex
+                                <button class="fa-wrapper" ng-if="vm.settings.localPathRgx.length > 0">
+                                    <i class="fas fa-check fa-sm" style="color: green;"></i>
+                                </button>
+                                <button class="fa-wrapper" ng-if="!vm.settings.localPathRgx.length > 0">
+                                    <i class="fas fa-asterisk fa-sm" style="color: red;"></i>
+                                </button>
+                            </label>
+                            <div class="col-sm-9 no-padding-right">
+                                <div class="col-md-6 no-padding-left">
+                                    <div class="input-group">
+                                        <input id="localPath"
+                                               type="text"
+                                               placeholder="Add Local File Path Regex..."
+                                               class="form-control input-sm"
+                                               ng-model="vm.localFilePath"
+                                               ng-keypress="vm.onEnter($event, vm.settings.localPathRgx, 'LocalFilePath')">
+                                        <span class="input-group-btn">
+                                            <button class="btn btn-default btn-sm"
+                                                    type="button"
+                                                    ng-click="vm.AddLocalFile(vm.settings.localPathRgx)">
+                                                <i class="fas fa-plus"></i>
+                                            </button>
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="col-md-6 no-padding">
+                                    <span ng-repeat="path in vm.settings.localPathRgx track by $index"
+                                          class="btn btn-default btn-sm"
+                                          style="margin-left: 1px; margin-right: 1px; margin-bottom: 2px;"
+                                          ng-click="vm.Remove(vm.settings.localPathRgx, $index)">
+                                        {{path}}
+                                    </span>
+                                </div>
+                            </div>
+                        </fieldset>
                    </form>
                    <button id="submitButton"
                            type="submit"


### PR DESCRIPTION
### READY

This PR adds a new setting to the global settings that allow us to check whether a file is a valid local file path. This used to be done by checking if the file path starts with `\\\\group\\hok\\` but if MC was to be installed locally or for some other company, then we need a more generic check. This PR resolves that issue by introducing a REGEX pattern as an input: 

![image](https://user-images.githubusercontent.com/529781/57323782-6d431000-70d4-11e9-8a87-15f2d0b2f592.png)

This pattern is then used everywhere that we need to determine if file is considered "local":
- file paths table
- file paths shown in edit configuration control
- file paths shown in add configuration control
- .NET side of MC, where file path is published to MC

The way this pattern is tested is that a new Regex class is created from each of the submitted patterns, and if ANY matches the file path the path is passed: 

.NET
![image](https://user-images.githubusercontent.com/529781/57323968-daef3c00-70d4-11e9-82e6-623db4917f1d.png)

JS
![image](https://user-images.githubusercontent.com/529781/57324019-fbb79180-70d4-11e9-95b4-1de778ca2732.png)
