### PR TITLE
adds a new setting that will allow user to specify source of user loc…

### DIFF
--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -4,7 +4,7 @@
 var mongoose = require( 'mongoose' );
 
 var UserLocationSources = Object.freeze({
-    MachineName: 'Machine Name'
+    MachineName: 'MachineName'
 });
 
 var userLocationSchema = new mongoose.Schema(
@@ -64,7 +64,7 @@ var settingsSchema = new mongoose.Schema(
         userLocation: {
             type: userLocationSchema,
             default: {
-                source: 'Machine Name', 
+                source: 'MachineName',
                 pattern: '-(\\w+)-',
                 group: 1
             }

--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -3,14 +3,28 @@
  */
 var mongoose = require( 'mongoose' );
 
+var UserLocationSources = Object.freeze({
+    MachineName: 'Machine Name'
+});
+
+var userLocationSchema = new mongoose.Schema(
+    {
+        source: {
+            type: String,
+            enum: Object.values(UserLocationSources)
+        },
+        pattern: String,
+        group: Number
+    },
+    { _id: false }
+);
+
 var officeSchema = new mongoose.Schema(
     {
         name: String,
         code: [String]
     },
-    {
-        _id: false
-    }
+    { _id: false }
 );
 
 var settingsSchema = new mongoose.Schema(
@@ -43,7 +57,18 @@ var settingsSchema = new mongoose.Schema(
                 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
             ]
         },
-        localPathRgx: [String]
+        localPathRgx: {
+            type: [String],
+            default: ['^(C:\\\\Users\\\\ksobon)']
+        },
+        userLocation: {
+            type: userLocationSchema,
+            default: {
+                source: 'Machine Name', 
+                pattern: '-(\\w+)-',
+                group: 1
+            }
+        }
     }
 );
 
@@ -58,5 +83,7 @@ settingsSchema.statics.findOneOrCreate = function findOneOrCreate(condition, cal
         return result ? callback(err, result) : self.create(condition, function(err, result) { return callback(err, result); });
     });
 };
+
+Object.assign(settingsSchema.statics, UserLocationSources);
 
 mongoose.model( 'Settings', settingsSchema );

--- a/public/angular-app/data-factory/utility-service.js
+++ b/public/angular-app/data-factory/utility-service.js
@@ -7,7 +7,7 @@ function UtilityService(){
          * This should match what we have in Settings Schema/Mongoose.
          */
         userLocationsOptions: function() {
-            return ['Machine Name'];
+            return ['MachineName'];
         },
 
         /**

--- a/public/angular-app/data-factory/utility-service.js
+++ b/public/angular-app/data-factory/utility-service.js
@@ -3,6 +3,14 @@ angular.module('MissionControlApp').factory('UtilityService', UtilityService);
 function UtilityService(){
     return {
         /**
+         * Method for obtaining an array of available User Location options. 
+         * This should match what we have in Settings Schema/Mongoose.
+         */
+        userLocationsOptions: function() {
+            return ['Machine Name'];
+        },
+
+        /**
          * Used for color formatting by all badge objects in health reports.
          * @returns {{red: string, orange: string, green: string, grey: string}}
          */

--- a/public/angular-app/settings/settings-controller.js
+++ b/public/angular-app/settings/settings-controller.js
@@ -3,7 +3,7 @@
  */
 angular.module('MissionControlApp').controller('SettingsController', SettingsController);
 
-function SettingsController(SettingsFactory, ngToast, $route){
+function SettingsController(SettingsFactory, ngToast, $route, UtilityService){
     var vm = this;
     var toasts = [];
     
@@ -11,8 +11,16 @@ function SettingsController(SettingsFactory, ngToast, $route){
     vm.office = { name: null, code: null };
     vm.state = null;
     vm.localFilePath = null;
+    vm.userLocationsOptions = UtilityService.userLocationsOptions();
 
     getSettings();
+
+    /**
+     * 
+     */
+    vm.setLocationSource = function(o) {
+        vm.settings.userLocation.source = o;
+    };
 
     /**
      * 

--- a/public/angular-app/settings/settings-controller.js
+++ b/public/angular-app/settings/settings-controller.js
@@ -16,6 +16,22 @@ function SettingsController(SettingsFactory, ngToast, $route, UtilityService){
     getSettings();
 
     /**
+     * Utility method for validating input Regex pattern.
+     */
+    vm.isValidUserLocation = function() {
+        if (vm.settings === null) return false;
+
+        var isValidPattern = true;
+        try {
+            new RegExp(vm.settings.userLocation.pattern);
+        } catch(err) {
+            isValidPattern = false;
+        }
+    
+        return vm.settings && vm.settings.userLocation && isValidPattern;
+    };
+
+    /**
      * 
      */
     vm.setLocationSource = function(o) {

--- a/public/angular-app/settings/settings.html
+++ b/public/angular-app/settings/settings.html
@@ -138,10 +138,10 @@
                         <fieldset class="form-group">
                             <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="userLocation">
                                 User Office Location Source
-                                <button class="fa-wrapper" ng-if="vm.settings.userLocation">
+                                <button class="fa-wrapper" ng-if="vm.isValidUserLocation()">
                                     <i class="fas fa-check fa-sm" style="color: green;"></i>
                                 </button>
-                                <button class="fa-wrapper" ng-if="!vm.settings.userLocation">
+                                <button class="fa-wrapper" ng-if="!vm.isValidUserLocation()">
                                     <i class="fas fa-asterisk fa-sm" style="color: red;"></i>
                                 </button>
                             </label>

--- a/public/angular-app/settings/settings.html
+++ b/public/angular-app/settings/settings.html
@@ -13,51 +13,51 @@
                <div class="panel-body">
                    <form class ="form-horizontal">
                         <fieldset class="form-group">
-                        <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="officeName">
-                            Office Locations
-                            <button class="fa-wrapper" ng-if="vm.settings.offices.length > 0">
-                                <i class="fas fa-check fa-sm" style="color: green;"></i>
-                            </button>
-                            <button class="fa-wrapper" ng-if="!vm.settings.offices.length > 0">
-                                <i class="fas fa-asterisk fa-sm" style="color: red;"></i>
-                            </button>
-                        </label>
-                        <div class="col-sm-9 no-padding-right">
-                            <div class="col-md-3 no-padding-left">
-                                <input id="officeName"
-                                       type="text"
-                                       placeholder="Add Office Location..."
-                                       class="form-control input-sm"
-                                       ng-model="vm.office.name"
-                                       ng-keypress="vm.onEnter($event, vm.settings.offices, 'Office')">
-                            </div>
-                            <div class="col-md-3 no-padding-left">
-                                <div class="input-group">
-                                    <input id="officeCode"
-                                           type="text"
-                                           placeholder="Add Office Code..."
-                                           class="form-control input-sm"
-                                           ng-model="vm.office.code"
-                                           ng-keypress="vm.onEnter($event, vm.settings.offices, 'Office')">
-                                    <span class="input-group-btn">
-                                        <button class="btn btn-default btn-sm"
-                                                type="button"
-                                                ng-click="vm.addValue(vm.settings.offices, 'Office')">
-                                            <i class="fas fa-plus"></i>
-                                        </button>
-                                    </span>
+                            <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="officeName">
+                                Office Locations
+                                <button class="fa-wrapper" ng-if="vm.settings.offices.length > 0">
+                                    <i class="fas fa-check fa-sm" style="color: green;"></i>
+                                </button>
+                                <button class="fa-wrapper" ng-if="!vm.settings.offices.length > 0">
+                                    <i class="fas fa-asterisk fa-sm" style="color: red;"></i>
+                                </button>
+                            </label>
+                            <div class="col-sm-9 no-padding-right">
+                                <div class="col-md-3 no-padding-left">
+                                    <input id="officeName"
+                                        type="text"
+                                        placeholder="Add Office Location..."
+                                        class="form-control input-sm"
+                                        ng-model="vm.office.name"
+                                        ng-keypress="vm.onEnter($event, vm.settings.offices, 'Office')">
+                                </div>
+                                <div class="col-md-3 no-padding-left">
+                                    <div class="input-group">
+                                        <input id="officeCode"
+                                            type="text"
+                                            placeholder="Add Office Code..."
+                                            class="form-control input-sm"
+                                            ng-model="vm.office.code"
+                                            ng-keypress="vm.onEnter($event, vm.settings.offices, 'Office')">
+                                        <span class="input-group-btn">
+                                            <button class="btn btn-default btn-sm"
+                                                    type="button"
+                                                    ng-click="vm.addValue(vm.settings.offices, 'Office')">
+                                                <i class="fas fa-plus"></i>
+                                            </button>
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="col-md-6 no-padding">
+                                        <span ng-repeat="office in vm.settings.offices track by $index"
+                                            ng-if="office.name != 'All'"
+                                            class="btn btn-default btn-sm"
+                                            style="margin-left: 1px; margin-right: 1px; margin-bottom: 2px;"
+                                            ng-click="vm.Remove(vm.settings.offices, $index)">
+                                            {{office.name}} - [{{office.code.join(",")}}]
+                                        </span>
                                 </div>
                             </div>
-                            <div class="col-md-6 no-padding">
-                                    <span ng-repeat="office in vm.settings.offices track by $index"
-                                          ng-if="office.name != 'All'"
-                                          class="btn btn-default btn-sm"
-                                          style="margin-left: 1px; margin-right: 1px; margin-bottom: 2px;"
-                                          ng-click="vm.Remove(vm.settings.offices, $index)">
-                                        {{office.name}} - [{{office.code.join(",")}}]
-                                    </span>
-                            </div>
-                        </div>
                         </fieldset>
                         <fieldset class="form-group">
                             <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="stateName">
@@ -132,6 +132,50 @@
                                           ng-click="vm.Remove(vm.settings.localPathRgx, $index)">
                                         {{path}}
                                     </span>
+                                </div>
+                            </div>
+                        </fieldset>
+                        <fieldset class="form-group">
+                            <label class="control-label col-sm-3 text-right" style="margin-top: 8px;" for="userLocation">
+                                User Office Location Source
+                                <button class="fa-wrapper" ng-if="vm.settings.userLocation">
+                                    <i class="fas fa-check fa-sm" style="color: green;"></i>
+                                </button>
+                                <button class="fa-wrapper" ng-if="!vm.settings.userLocation">
+                                    <i class="fas fa-asterisk fa-sm" style="color: red;"></i>
+                                </button>
+                            </label>
+                            <div class="col-sm-9 no-padding-right">
+                                <div class="col-md-6 no-padding-left">
+                                    <div class="btn-group" style="width:100%;">
+                                        <button class="btn btn-default btn-sm dropdown-toggle scrollable-menu-left" data-toggle="dropdown">
+                                            {{vm.settings.userLocation.source}}
+                                            <span class="caret pull-right" style="margin-top: 6px; margin-bottom: 6px;"></span>
+                                        </button>
+                                        <ul class="dropdown-menu scrollable-menu-left">
+                                            <li ng-repeat="o in vm.userLocationsOptions">
+                                                <a href="" ng-click="vm.setLocationSource(o)" class="no-padding-left no-padding-right">
+                                                    {{o}}
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div class="col-md-6 no-padding">
+                                    <div class="col-md-6 no-padding-left">
+                                        <input id="officeLocationPattern"
+                                               type="text"
+                                               placeholder="Add Office Location Regex..."
+                                               class="form-control input-sm"
+                                               ng-model="vm.settings.userLocation.pattern">
+                                    </div>
+                                    <div class="col-md-6 no-padding-left">
+                                        <input id="officeLocationGroup"
+                                               type="number"
+                                               placeholder="Pattern Group Number"
+                                               class="form-control input-sm"
+                                               ng-model="vm.settings.userLocation.group">
+                                    </div>
                                 </div>
                             </div>
                         </fieldset>


### PR DESCRIPTION
### READY

This adds a new settings option that will allow users to specify how to extract user location/office when .NET version of the plugin publishes info about plugins. Currently the method uses a hard coded setup where MachineName is extracted from user PC. This works under assumption that HOK machine names are following the pattern of XXX-YY-ZZZ where: 

- XXX is type of machine ex. LPT, DSK, etc. 
- YY is the office code ex. NY, CHI etc.
- ZZZ is the machine number ex. 100

With this settings we will allow user to still use the MachineName but instead of assuming that their naming convention matches that of HOK, we will allow them to specify a Regex pattern + group to extract the office location from. 

![image](https://user-images.githubusercontent.com/529781/57471509-46faad00-7259-11e9-9b40-6aedcbdbce32.png)

This example will parse the above string into two groups: 

- "-YY-"
- YY

By allowing user to select which group their want we can extract the computer name. Also, this method and schema will allow future expansion to get the location from other sources. 