### PR TITLE
Feature/recognize citrix machines

### DIFF
--- a/app/models/settings.js
+++ b/app/models/settings.js
@@ -1,9 +1,13 @@
 /**
  * Created by konrad.sobon on 2019-05-02.
  */
-var mongoose = require( 'mongoose' );
+var mongoose = require('mongoose');
 
 var UserLocationSources = Object.freeze({
+    MachineName: 'MachineName'
+});
+
+var TempLocationSources = Object.freeze({
     MachineName: 'MachineName'
 });
 
@@ -44,6 +48,18 @@ var userLocationSchema = new mongoose.Schema(
         pattern: String,
         match: Number,
         group: Number
+    },
+    { _id: false }
+);
+
+var tempLocationSchema = new mongoose.Schema(
+    {
+        source: {
+            type: String,
+            enum: Object.values(TempLocationSources)
+        },
+        pattern: String,
+        tempPath: String
     },
     { _id: false }
 );
@@ -121,6 +137,14 @@ var settingsSchema = new mongoose.Schema(
                     bimThreeSixty: { pattern: '', match: 0, group: 1 }
                 }
             }
+        },
+        tempLocation: {
+            type: tempLocationSchema,
+            default: {
+                source: 'MachineName',
+                pattern: 'svr$',
+                tempPath: 'B:\\Temp'
+            }
         }
     }
 );
@@ -132,11 +156,11 @@ var settingsSchema = new mongoose.Schema(
  */
 settingsSchema.statics.findOneOrCreate = function findOneOrCreate(condition, callback) {
     var self = this;
-    self.findOne(condition, function(err, result) {
-        return result ? callback(err, result) : self.create(condition, function(err, result) { return callback(err, result); });
+    self.findOne(condition, function (err, result) {
+        return result ? callback(err, result) : self.create(condition, function (err, result) { return callback(err, result); });
     });
 };
 
 Object.assign(settingsSchema.statics, UserLocationSources);
 
-mongoose.model( 'Settings', settingsSchema );
+mongoose.model('Settings', settingsSchema);

--- a/public/angular-app/data-factory/utility-service.js
+++ b/public/angular-app/data-factory/utility-service.js
@@ -6,6 +6,14 @@ function UtilityService() {
          * Method for obtaining an array of available User Location options. 
          * This should match what we have in Settings Schema/Mongoose.
          */
+        tempLocationsOptions: function () {
+            return ['MachineName'];
+        },
+
+        /**
+         * Method for obtaining an array of available User Location options. 
+         * This should match what we have in Settings Schema/Mongoose.
+         */
         userLocationsOptions: function () {
             return ['MachineName'];
         },

--- a/public/angular-app/settings/settings-controller.js
+++ b/public/angular-app/settings/settings-controller.js
@@ -15,6 +15,7 @@ function SettingsController(SettingsFactory, ngToast, $route, UtilityService) {
     vm.state = null;
     vm.localFilePath = null;
     vm.userLocationsOptions = UtilityService.userLocationsOptions();
+    vm.tempLocationsOptions = UtilityService.tempLocationsOptions();
     vm.projectInfoSources = UtilityService.projectInfoSources();
 
     getSettings();
@@ -61,8 +62,15 @@ function SettingsController(SettingsFactory, ngToast, $route, UtilityService) {
     /**
      * 
      */
-    vm.setLocationSource = function (o) {
-        vm.settings.userLocation.source = o;
+    vm.setLocationSource = function (source, action) {
+        switch (action) {
+            case 'Office':
+                vm.settings.userLocation.source = source;
+                break;
+            case 'Temp':
+                vm.settings.tempLocationsOptions = source;
+                break;
+        }
     };
 
     /**

--- a/public/angular-app/settings/settings.html
+++ b/public/angular-app/settings/settings.html
@@ -185,7 +185,7 @@
                                         <ul class="dropdown-menu scrollable-menu-left">
                                             <li ng-repeat="o in vm.userLocationsOptions">
                                                 <a href=""
-                                                   ng-click="vm.setLocationSource(o)"
+                                                   ng-click="vm.setLocationSource(o, 'Office')"
                                                    class="no-padding-left no-padding-right">
                                                     {{o}}
                                                 </a>
@@ -216,6 +216,92 @@
                                                ng-model="vm.settings.userLocation.group">
                                     </div>
                                 </div>
+                            </div>
+                        </fieldset>
+                    </form>
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="row">
+        <form name="form"
+              class="css-form"
+              novalidate>
+            <div class="panel panel-default"
+                 style="margin-top:10px;">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Temp Location Info</h3>
+                </div>
+                <div class="panel-body">
+                    <form class="form-horizontal">
+                        <fieldset class="form-group">
+                            <label class="control-label col-sm-3 text-right"
+                                   style="margin-top: 8px;"
+                                   for="userLocation">
+                                Citrix Machine Identifier Source
+                                <button class="fa-wrapper"
+                                        ng-if="vm.isValidRegex(vm.settings.tempLocation.pattern)">
+                                    <i class="fas fa-check fa-sm"
+                                       style="color: green;"></i>
+                                </button>
+                                <button class="fa-wrapper"
+                                        ng-if="!vm.isValidRegex(vm.settings.tempLocation.pattern)">
+                                    <i class="fas fa-asterisk fa-sm"
+                                       style="color: red;"></i>
+                                </button>
+                            </label>
+                            <div class="col-sm-9 no-padding-right">
+                                <div class="col-md-6 no-padding-left">
+                                    <div class="btn-group"
+                                         style="width:100%;">
+                                        <button class="btn btn-default btn-sm dropdown-toggle scrollable-menu-left"
+                                                data-toggle="dropdown">
+                                            {{vm.settings.tempLocation.source}}
+                                            <span class="caret pull-right"
+                                                  style="margin-top: 6px; margin-bottom: 6px;"></span>
+                                        </button>
+                                        <ul class="dropdown-menu scrollable-menu-left">
+                                            <li ng-repeat="o in vm.tempLocationsOptions">
+                                                <a href=""
+                                                   ng-click="vm.setLocationSource(o, 'Temp')"
+                                                   class="no-padding-left no-padding-right">
+                                                    {{o}}
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div class="col-md-6 no-padding-left">
+                                    <input id="officeLocationPattern"
+                                           type="text"
+                                           placeholder="Temp Location Regex."
+                                           class="form-control input-sm"
+                                           ng-model="vm.settings.tempLocation.pattern">
+                                </div>
+                            </div>
+                        </fieldset>
+                        <fieldset class="form-group">
+                            <label class="control-label col-sm-3 text-right"
+                                   style="margin-top: 8px;"
+                                   for="userLocation">
+                                Citrix Machine Temp Folder Path
+                                <button class="fa-wrapper"
+                                        ng-if="vm.settings.tempLocation.tempPath">
+                                    <i class="fas fa-check fa-sm"
+                                       style="color: green;"></i>
+                                </button>
+                                <button class="fa-wrapper"
+                                        ng-if="!vm.settings.tempLocation.tempPath">
+                                    <i class="fas fa-asterisk fa-sm"
+                                       style="color: red;"></i>
+                                </button>
+                            </label>
+                            <div class="col-sm-9">
+                                <input id="officeLocationPattern"
+                                       type="text"
+                                       placeholder="Temp Folder Location."
+                                       class="form-control input-sm"
+                                       ng-model="vm.settings.tempLocation.tempPath">
                             </div>
                         </fieldset>
                     </form>


### PR DESCRIPTION
### READY

This adds new settings for recognizing Citrix machines. Currently we use a Machine Name based check knowing that Citrix machines end with "svr". This can be replaced with a Regex based check where user can pick the method. I can see at least one more type of check that we can do in the future, and that would be checking if user has a Citrix client installed. 

Once we verify that user is indeed on a Citric machine, they don't have a local temp folder on a C drive like most other machines. C access is restricted on Citrix machines, so we need input from user with a temp folder location. Family Publishing tool uses that to temporarily export the families there to get proper file size etc. 

![image](https://user-images.githubusercontent.com/529781/57938104-6d41cd80-7895-11e9-95c5-b0ee87213f77.png)
