### PR TITLE
isDisabled null check

### DIFF
--- a/app/controller/filepaths.js
+++ b/app/controller/filepaths.js
@@ -295,8 +295,8 @@ FilePathsService = {
         var fileType = req.body['fileType'];
         var query = {};
 
-        // (Konrad) Always check if disabled.
-        query['isDisabled'] = disabled !== 'false';
+        // (Dan) Always check if disabled. Account for null or missing values.
+        query['isDisabled'] = disabled !== 'false' ? true : { $ne: true };
 
         // (Konrad) Additional filters.
         if (revitVersion !== 'All') query['revitVersion'] = revitVersion;


### PR DESCRIPTION
Some file paths were created without the `isDisabled` field, so instead of true/false, there's the potential for true/false/null. The query for the `filepaths` datatable ends up explicitly being `isDisabled === true` or `isDisabled === false`, which excludes the (currently) 70% of filepaths without this field. 

This fix will return either file paths that are all disabled (`isDisabled === true`), or file paths that are not disabled or no value is set (`isDisabled !== true`). At the same time, I'll do a PR to ensure that `isDisabled` is always initialized to `false`